### PR TITLE
Control of soc and scissor options BoltzTraP + VaspToDbTask

### DIFF
--- a/matmethods/vasp/firetasks/parse_outputs.py
+++ b/matmethods/vasp/firetasks/parse_outputs.py
@@ -58,10 +58,8 @@ class VaspToDbTask(FireTaskBase):
         defuse_unsuccessful (bool): Defuses children fireworks if VASP run state
             is not "successful"; i.e. both electronic and ionic convergence are reached.
             Defaults to True.
-        check_all_files (bool): whether to check for existence of all the files that VASP
-            normally creat upon running. Defaults to True.
     """
-    optional_params = ["calc_dir", "calc_loc", "parse_dos", "bandstructure_mode", "check_all_files",
+    optional_params = ["calc_dir", "calc_loc", "parse_dos", "bandstructure_mode",
                        "additional_fields", "db_file", "fw_spec_fields", "defuse_unsuccessful"]
 
     def run_task(self, fw_spec):
@@ -74,14 +72,6 @@ class VaspToDbTask(FireTaskBase):
 
         # parse the VASP directory
         logger.info("PARSING DIRECTORY: {}".format(calc_dir))
-
-        if "check_all_files" in self and not self["check_all_files"]:
-            pass
-        else:
-            for vfile in ["EIGENVAL","CHG","CHGCAR","CONTCAR","DOSCAR","OSZICAR","OUTCAR","PCDAT","WAVECAR"]:
-                if not os.path.exists(os.path.join(calc_dir, vfile)):
-                    raise IOError("Did VASP start? {} is missing; if that is ok rerun with check_all_files=False"\
-                                  .format(vfile))
 
         # get the database connection
         db_file = env_chk(self.get('db_file'), fw_spec)

--- a/matmethods/vasp/firetasks/parse_outputs.py
+++ b/matmethods/vasp/firetasks/parse_outputs.py
@@ -58,8 +58,10 @@ class VaspToDbTask(FireTaskBase):
         defuse_unsuccessful (bool): Defuses children fireworks if VASP run state
             is not "successful"; i.e. both electronic and ionic convergence are reached.
             Defaults to True.
+        check_all_files (bool): whether to check for existence of all the files that VASP
+            normally creat upon running. Defaults to True.
     """
-    optional_params = ["calc_dir", "calc_loc", "parse_dos", "bandstructure_mode",
+    optional_params = ["calc_dir", "calc_loc", "parse_dos", "bandstructure_mode", "check_all_files",
                        "additional_fields", "db_file", "fw_spec_fields", "defuse_unsuccessful"]
 
     def run_task(self, fw_spec):
@@ -72,6 +74,15 @@ class VaspToDbTask(FireTaskBase):
 
         # parse the VASP directory
         logger.info("PARSING DIRECTORY: {}".format(calc_dir))
+
+        if "check_all_files" in self and not self["check_all_files"]:
+            pass
+        else:
+            for vfile in ["EIGENVAL","CHG","CHGCAR","CONTCAR","DOSCAR","OSZICAR","OUTCAR","PCDAT","WAVECAR"]:
+                if not os.path.exists(os.path.join(calc_dir, vfile)):
+                    raise IOError("Did VASP start? {} is missing; if that is ok rerun with check_all_files=False"\
+                                  .format(vfile))
+
         # get the database connection
         db_file = env_chk(self.get('db_file'), fw_spec)
 

--- a/matmethods/vasp/firetasks/run_calc.py
+++ b/matmethods/vasp/firetasks/run_calc.py
@@ -177,7 +177,7 @@ class RunBoltztrap(FireTaskBase):
         (none)
 
     Optional params:
-        scissor: (float) scissor band gap amount in eV
+        scissor: (float) scissor band gap amount in eV (i.e. new gap == scissor)
         tmax: (float) max temperature to evaluate (default = 1300K)
         tgrid: (float) temperature interval (default = 50K)
         doping: ([float]) doping levels you want to compute

--- a/matmethods/vasp/firetasks/run_calc.py
+++ b/matmethods/vasp/firetasks/run_calc.py
@@ -181,20 +181,22 @@ class RunBoltztrap(FireTaskBase):
         tmax: (float) max temperature to evaluate (default = 1300K)
         tgrid: (float) temperature interval (default = 50K)
         doping: ([float]) doping levels you want to compute
+        soc: (bool) whether the band structure is calculated with spin-orbit coupling or not
     """
 
-    optional_params = ["scissor", "tmax", "tgrid", "doping"]
+    optional_params = ["scissor", "tmax", "tgrid", "doping", "soc"]
 
     def run_task(self, fw_spec):
         scissor = self.get("scissor", 0.0)
         tmax = self.get("tmax", 1300)
         tgrid = self.get("tgrid", 50)
         doping = self.get("doping", None)
+        soc = self.get("soc", False)
 
         vasprun, outcar = get_vasprun_outcar(".", parse_dos=True, parse_eigen=True)
         bs = vasprun.get_band_structure()
         nelect = outcar.nelect
-        runner = BoltztrapRunner(bs, nelect, scissor=scissor, doping=doping, tmax=tmax, tgrid=tgrid)
+        runner = BoltztrapRunner(bs, nelect, scissor=scissor, doping=doping, tmax=tmax, tgrid=tgrid, soc=soc)
         runner.run(path_dir=os.getcwd())
 
 

--- a/matmethods/vasp/fireworks/core.py
+++ b/matmethods/vasp/fireworks/core.py
@@ -338,20 +338,22 @@ class MDFW(Firework):
 
 class BoltztrapFW(Firework):
     def __init__(self, structure, name="boltztrap", db_file=None,
-                 parents=None, **kwargs):
+                 parents=None, scissor=0.0, soc=False, **kwargs):
         """
         Run Boltztrap
 
         Args:
-            structure: (Structure) - only used for setting name of FW
-            name: (str) name of this FW
+            structure (Structure): - only used for setting name of FW
+            name (str): name of this FW
             parents (Firework): Parents of this particular Firework. FW or list of FWS.
+            scissor (float): if scissor > 0, apply scissor on the band structure so that new band gap = scissor (in eV)
+            soc (bool): whether the band structure is calculated with spin-orbit coupling
             \*\*kwargs: Other kwargs that are passed to Firework.__init__.
         """
 
         t = []
         t.append(CopyVaspOutputs(calc_loc=True, contcar_to_poscar=True))
-        t.append(RunBoltztrap())
+        t.append(RunBoltztrap(scissor=scissor, soc=soc))
         t.append(BoltztrapToDBTask(db_file=db_file))
         t.append(PassCalcLocs(name=name))
         super(BoltztrapFW, self).__init__(t, parents=parents, name="{}-{}".format(


### PR DESCRIPTION
## Summary

* BoltztrapRunner on a band structure that is run with spin-orbit coupling requires the argument soc to be set to True, so I added this option explicitly to BoltztrapFW , etc

* It turns out scissor is actually the final band gap, so I made this clear in the documentation and added this to BoltztrapFW as well for more control.

