### PR TITLE
Minor changes to elastic workflow

### DIFF
--- a/atomate/vasp/workflows/base/deformations.py
+++ b/atomate/vasp/workflows/base/deformations.py
@@ -58,6 +58,7 @@ def get_wf_deformations(structure, deformations, name="deformation", vasp_input_
     uis_static = {"ISIF": 2, "ISTART":1}
     if relax_deformed:
         uis_static["IBRION"] = 2
+        uis_static["NSW"] = 99
 
     # static input set
     vis_static = MPStaticSet(structure, force_gamma=True, lepsilon=lepsilon,

--- a/atomate/vasp/workflows/base/elastic.py
+++ b/atomate/vasp/workflows/base/elastic.py
@@ -7,6 +7,7 @@ This module defines the elastic workflow
 """
 
 from pymatgen.analysis.elasticity.strain import Deformation
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen import Structure
 
 from fireworks import Firework, Workflow
@@ -23,7 +24,7 @@ logger = get_logger(__name__)
 
 def get_wf_elastic_constant(structure, vasp_input_set=None, vasp_cmd="vasp", norm_deformations=None,
                             shear_deformations=None, additional_deformations=None, db_file=None,
-                            user_kpoints_settings=None, add_analysis_task=True):
+                            user_kpoints_settings=None, add_analysis_task=True, conventional=True):
     """
     Returns a workflow to calculate elastic constants.
 
@@ -50,7 +51,9 @@ def get_wf_elastic_constant(structure, vasp_input_set=None, vasp_cmd="vasp", nor
     Returns:
         Workflow
     """
-
+    # Convert to conventional
+    if conventional:
+        structure = SpacegroupAnalyzer(structure).get_conventional_standard_structure()
     # Generate deformations
     deformations = []
 

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -199,9 +199,8 @@ def wf_elastic_constant(structure, c=None):
                                  norm_deformations=norm_deformations,
                                  shear_deformations=shear_deformations,
                                  db_file=db_file, user_kpoints_settings=user_kpoints_settings)
-
-    wf = add_modify_incar(wf, modify_incar_params={"incar_update":
-                                                   {"ENCUT": 700, "EDIFF": 1e-6}})
+    mip = {"incar_update":{"ENCUT": 700, "EDIFF": 1e-6, "LAECHG":False}}
+    wf = add_modify_incar(wf, modify_incar_params=mip)
 
     wf = add_common_powerups(wf, c)
 

--- a/atomate/vasp/workflows/tests/test_elastic_workflow.py
+++ b/atomate/vasp/workflows/tests/test_elastic_workflow.py
@@ -131,7 +131,11 @@ class TestElasticWorkflow(unittest.TestCase):
         self.wf = self._simulate_vasprun(self.wf)
 
         self.assertEqual(len(self.wf.fws), 8)
-
+        # check vasp parameters for ionic relaxation
+        defo_vis = [fw.spec["_tasks"][2]['vasp_input_set'] 
+                    for fw in self.wf.fws if "deform" in fw.name]
+        assert all([vis['user_incar_settings']['NSW']==99 for vis in defo_vis])
+        assert all([vis['user_incar_settings']['IBRION']==2 for vis in defo_vis])
         self.lp.add_wf(self.wf)
         rapidfire(self.lp, fworker=FWorker(env={"db_file": os.path.join(db_dir, "db.json")}))
 


### PR DESCRIPTION
## Summary

@albalu pointed out a few discrepancies in calculated elastic constants and MP.  This PR should ensure that the MP workflow is replicated via the `wf_elastic_constant` in `vasp.workflows.presets.core`.  Also added a few lines to unit test to ensure that the relevant issue (i.e. vasp parameters) are verified.