### PR TITLE
add the ability to choose ObjectId in insert_gridfs

### DIFF
--- a/atomate/vasp/database.py
+++ b/atomate/vasp/database.py
@@ -64,7 +64,7 @@ class MMVaspDb(MMDb):
                                           ("completed_at", DESCENDING)],
                                          background=background)
 
-    def insert_gridfs(self, d, collection="fs", compress=True, _id=ObjectId()):
+    def insert_gridfs(self, d, collection="fs", compress=True, id=None):
         """
         Insert the given document into GridFS.
 
@@ -72,14 +72,16 @@ class MMVaspDb(MMDb):
             d (dict): the document
             collection (string): the GridFS collection name
             compress (bool): Whether to compress the data or not
+            id (ObjectId()): the _id of the file; if specified, it must not already exist in GridFS
 
         Returns:
             file id, the type of compression used.
         """
+        id = id or ObjectId()
         if compress:
             d = zlib.compress(d.encode(), compress)
         fs = gridfs.GridFS(self.db, collection)
-        fs_id = fs.put(d, _id=_id)
+        fs_id = fs.put(d, id=id)
         return fs_id, "zlib"
 
     def get_band_structure(self, task_id, line_mode=False):

--- a/atomate/vasp/database.py
+++ b/atomate/vasp/database.py
@@ -10,6 +10,7 @@ This module defines the database classes.
 
 import zlib
 import json
+from bson import ObjectId
 
 from pymatgen.electronic_structure.bandstructure import BandStructure, BandStructureSymmLine
 
@@ -63,7 +64,7 @@ class MMVaspDb(MMDb):
                                           ("completed_at", DESCENDING)],
                                          background=background)
 
-    def insert_gridfs(self, d, collection="fs", compress=True):
+    def insert_gridfs(self, d, collection="fs", compress=True, _id=ObjectId()):
         """
         Insert the given document into GridFS.
 
@@ -78,7 +79,7 @@ class MMVaspDb(MMDb):
         if compress:
             d = zlib.compress(d.encode(), compress)
         fs = gridfs.GridFS(self.db, collection)
-        fs_id = fs.put(d)
+        fs_id = fs.put(d, _id=_id)
         return fs_id, "zlib"
 
     def get_band_structure(self, task_id, line_mode=False):

--- a/atomate/vasp/database.py
+++ b/atomate/vasp/database.py
@@ -64,7 +64,7 @@ class MMVaspDb(MMDb):
                                           ("completed_at", DESCENDING)],
                                          background=background)
 
-    def insert_gridfs(self, d, collection="fs", compress=True, id=None):
+    def insert_gridfs(self, d, collection="fs", compress=True, oid=None):
         """
         Insert the given document into GridFS.
 
@@ -72,16 +72,16 @@ class MMVaspDb(MMDb):
             d (dict): the document
             collection (string): the GridFS collection name
             compress (bool): Whether to compress the data or not
-            id (ObjectId()): the _id of the file; if specified, it must not already exist in GridFS
+            oid (ObjectId()): the _id of the file; if specified, it must not already exist in GridFS
 
         Returns:
             file id, the type of compression used.
         """
-        id = id or ObjectId()
+        oid = oid or ObjectId()
         if compress:
             d = zlib.compress(d.encode(), compress)
         fs = gridfs.GridFS(self.db, collection)
-        fs_id = fs.put(d, id=id)
+        fs_id = fs.put(d, id=oid)
         return fs_id, "zlib"
 
     def get_band_structure(self, task_id, line_mode=False):


### PR DESCRIPTION
## Summary

I may want to rebuild/update a collection (e.g. boltztrap + boltztrap DOS) but keep the old object ids and in a sense just update some of the documents w/o changing the ids, this small change to the code let me do that without changing its default functionality,