### PR TITLE
formation energy per atom in builder + more general tag_fws

### DIFF
--- a/atomate/vasp/builders/materials_ehull.py
+++ b/atomate/vasp/builders/materials_ehull.py
@@ -52,6 +52,13 @@ class MaterialsEhullBuilder(AbstractBuilder):
                 self._materials.update_one({"material_id": m["material_id"]},
                                            {"$set": {"stability": self.mpr.get_stability([my_entry])[0]}})
 
+                for el, elx in my_entry.composition.items():
+                    entries = self.mpr.get_entries(el.symbol)
+                    min_e = min(entries, key=lambda x: x.energy_per_atom).energy_per_atom
+                    energy -= elx * min_e
+                self._materials.update_one({"material_id": m["material_id"]},
+                                           {"$set": {"thermo.formation_energy_per_atom": energy / structure.num_sites}})
+
                 mpids = self.mpr.find_structure(structure)
                 self._materials.update_one({"material_id": m["material_id"]}, {"$set": {"mpids": mpids}})
 

--- a/atomate/vasp/builders/materials_ehull.py
+++ b/atomate/vasp/builders/materials_ehull.py
@@ -53,7 +53,7 @@ class MaterialsEhullBuilder(AbstractBuilder):
                                            {"$set": {"stability": self.mpr.get_stability([my_entry])[0]}})
 
                 for el, elx in my_entry.composition.items():
-                    entries = self.mpr.get_entries(el.symbol)
+                    entries = self.mpr.get_entries(el.symbol, compatible_only=True)
                     min_e = min(entries, key=lambda x: x.energy_per_atom).energy_per_atom
                     energy -= elx * min_e
                 self._materials.update_one({"material_id": m["material_id"]},

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -221,8 +221,8 @@ def tag_fws(original_wf, tag, fw_name_constraint=None, task_name_constraint=None
     Args:
         original_wf (Workflow):
         tag (string): user-defined tag to be added under fw.spec._fworker (e.g. "large memory", "big", etc)
-        fw_name_constraint (string): name of the fireworks to be tagged (all if None is passed)
-        task_name_constraint (string): name of the firetasks to be tagged (e.g. None or 'RunVasP')
+        fw_name_constraint (string): name of the Fireworks to be tagged (all if None is passed)
+        task_name_constraint (string): name of the Firetasks to be tagged (e.g. None or 'RunVasp')
 
     Returns:
         modified workflow with tagged Fireworkers

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -214,21 +214,22 @@ def modify_to_soc(original_wf, nbands, structure=None, modify_incar_params=None,
 
     return Workflow.from_dict(wf_dict)
 
-def tag_fws(original_wf, tag, fw_name_constraint=None):
+def tag_fws(original_wf, tag, fw_name_constraint=None, task_name_constraint=None):
     """
-    Tags VASP Fworker(s) of a Workflow; e.g. it can be used to run large-memory jobs on a separate queue
+    Tags Fireworker(s) of a Workflow; e.g. it can be used to run large-memory jobs on a separate queue.
 
     Args:
         original_wf (Workflow):
         tag (string): user-defined tag to be added under fw.spec._fworker (e.g. "large memory", "big", etc)
-        fw_name_constraint (string): name of the fireworks to be modified (all if None is passed)
+        fw_name_constraint (string): name of the fireworks to be tagged (all if None is passed)
+        task_name_constraint (string): name of the firetasks to be tagged (e.g. None or 'RunVasP')
 
     Returns:
-        modified workflow with tagged Fworkers
+        modified workflow with tagged Fireworkers
     """
     wf_dict = original_wf.to_dict()
     for idx_fw, idx_t in get_fws_and_tasks(original_wf, fw_name_constraint=fw_name_constraint,
-                                           task_name_constraint="RunVasp"):
+                                           task_name_constraint=task_name_constraint):
         wf_dict["fws"][idx_fw]["spec"]["_fworker"] = tag
 
     return Workflow.from_dict(wf_dict)

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -351,8 +351,8 @@ def tag_fws(original_wf, tag, fw_name_constraint=None, task_name_constraint=None
     Args:
         original_wf (Workflow):
         tag (string): user-defined tag to be added under fw.spec._fworker (e.g. "large memory", "big", etc)
-        fw_name_constraint (string): name of the fireworks to be tagged (all if None is passed)
-        task_name_constraint (string): name of the firetasks to be tagged (e.g. None or "RunVasP")
+        fw_name_constraint (string): name of the Fireworks to be tagged (all if None is passed)
+        task_name_constraint (string): name of the Firetasks to be tagged (e.g. None or "RunVasp")
 
     Returns:
         modified workflow with tagged Fireworkers

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -411,17 +411,15 @@ def add_additional_fields_to_taskdocs(original_wf, update_dict=None):
     return Workflow.from_dict(wf_dict)
 
 
-def add_tags(original_wf, tags_list, task_name_constraints='ToD'):
+def add_tags(original_wf, tags_list):
     """
     Adds tags to all Fireworks in the Workflow, WF metadata,
-    as well as additional_fields for specific tasks specified by task_name_constraints
-    to track them later (e.g. all fireworks and vasp tasks related to a research project)
+     as well as additional_fields for the VaspDrone to track them later
+     (e.g. all fireworks and vasp tasks related to a research project)
 
     Args:
         original_wf (Workflow)
-        tags_list ([string]): list of tags parameters
-        task_name_constraints (string): default is 'ToD'; e.g. in VaspToDbTask, BoltztrapToDBTask, ElasticTensorToDbTask
-
+        tags_list: list of tags parameters (list of strings)
     """
     wf_dict = original_wf.to_dict()
 
@@ -439,7 +437,7 @@ def add_tags(original_wf, tags_list, task_name_constraints='ToD'):
             wf_dict["fws"][idx_fw]["spec"]["tags"] = tags_list
 
     # Drone
-    for idx_fw, idx_t in get_fws_and_tasks(original_wf, task_name_constraint=task_name_constraints):
+    for idx_fw, idx_t in get_fws_and_tasks(original_wf, task_name_constraint="VaspToDbTask"):
         if "tags" in wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]:
             wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]["tags"].extend(tags_list)
         else:

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -411,15 +411,17 @@ def add_additional_fields_to_taskdocs(original_wf, update_dict=None):
     return Workflow.from_dict(wf_dict)
 
 
-def add_tags(original_wf, tags_list):
+def add_tags(original_wf, tags_list, task_name_constraints='ToD'):
     """
     Adds tags to all Fireworks in the Workflow, WF metadata,
-     as well as additional_fields for the VaspDrone to track them later
-     (e.g. all fireworks and vasp tasks related to a research project)
+    as well as additional_fields for specific tasks specified by task_name_constraints
+    to track them later (e.g. all fireworks and vasp tasks related to a research project)
 
     Args:
         original_wf (Workflow)
-        tags_list: list of tags parameters (list of strings)
+        tags_list ([string]): list of tags parameters
+        task_name_constraints (string): default is 'ToD'; e.g. in VaspToDbTask, BoltztrapToDBTask, ElasticTensorToDbTask
+
     """
     wf_dict = original_wf.to_dict()
 
@@ -437,7 +439,7 @@ def add_tags(original_wf, tags_list):
             wf_dict["fws"][idx_fw]["spec"]["tags"] = tags_list
 
     # Drone
-    for idx_fw, idx_t in get_fws_and_tasks(original_wf, task_name_constraint="VaspToDbTask"):
+    for idx_fw, idx_t in get_fws_and_tasks(original_wf, task_name_constraint=task_name_constraints):
         if "tags" in wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]:
             wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]["tags"].extend(tags_list)
         else:


### PR DESCRIPTION
## Summary

1. I implemented formation energy per atom in the Ehull builder before so it's tested but I forgot to merge it before.

2. users now have more control over tag_fws to tag the entire workflow and not just VaspRun jobs
