### PR TITLE
more control over materials builder + add_tags also through BoltztrapFW and BoltztrapToDBTask

### DIFF
--- a/atomate/vasp/builders/tasks_materials.py
+++ b/atomate/vasp/builders/tasks_materials.py
@@ -26,7 +26,8 @@ module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 
 
 class TasksMaterialsBuilder(AbstractBuilder):
-    def __init__(self, materials_write, counter_write, tasks_read, tasks_prefix="t", materials_prefix="m"):
+    def __init__(self, materials_write, counter_write, tasks_read, tasks_prefix="t", materials_prefix="m",
+                 excluded_tasks=None):
         """
         Create a materials collection from a tasks collection.
 
@@ -34,6 +35,7 @@ class TasksMaterialsBuilder(AbstractBuilder):
             materials_write (pymongo.collection): mongodb collection for materials (write access needed)
             counter_write (pymongo.collection): mongodb collection for counter (write access needed)
             tasks_read (pymongo.collection): mongodb collection for tasks (suggest read-only for safety)
+            excluded_tasks (dict): a query on tasks_read for the tasks to be excluded from the materials collection
         """
         x = loadfn(os.path.join(module_dir, "tasks_materials_settings.yaml"))
         self.supported_task_labels = x['supported_task_labels']
@@ -53,6 +55,7 @@ class TasksMaterialsBuilder(AbstractBuilder):
 
         self._t_prefix = tasks_prefix
         self._m_prefix = materials_prefix
+        self.excluded_tasks = excluded_tasks
 
     def tid_str(self, task_id):
         # converts int material_id to string
@@ -73,11 +76,17 @@ class TasksMaterialsBuilder(AbstractBuilder):
         for m in self._materials.find({}, {"_tasksbuilder.all_task_ids": 1}):
             previous_task_ids.extend(m["_tasksbuilder"]["all_task_ids"])
 
+        excluded_task_ids = []
+        if self.excluded_tasks:
+            for task in self._tasks.find(self.excluded_tasks):
+                excluded_task_ids.append("{}-{}".format(self._t_prefix, task["task_id"]))
+
         all_task_ids = [self.tid_str(t["task_id"])
                         for t in self._tasks.find({"state": "successful",
                                                    "task_label": {"$in": self.supported_task_labels}},
                                                   {"task_id": 1})]
-        task_ids = [t_id for t_id in all_task_ids if t_id not in previous_task_ids]
+        task_ids = [t_id for t_id in all_task_ids if t_id not in previous_task_ids and t_id not in excluded_task_ids]
+
 
         print("There are {} new task_ids to process.".format(len(task_ids)))
 

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -138,14 +138,21 @@ class BoltztrapToDBTask(FiretaskBase):
         db_file (str): path to file containing the database credentials.
             Supports env_chk. Default: write data to JSON file.
         hall_doping (bool): set True to retain hall_doping in dict
+        additional_fields (dict): fields added to the document such as user-defined tags or name, ids, etc
     """
 
-    optional_params = ["db_file", "hall_doping"]
+    optional_params = ["db_file", "hall_doping", "additional_fields"]
 
     def run_task(self, fw_spec):
+        additional_fields = self.get("additional_fields", {})
+        # pass the additional_fields first to avoid overriding BoltztrapAnalyzer items
+        d = additional_fields.copy()
+
         btrap_dir = os.path.join(os.getcwd(), "boltztrap")
         bta = BoltztrapAnalyzer.from_files(btrap_dir)
-        d = bta.as_dict()
+        for key in bta.as_dict():
+            d[key] = bta.as_dict()[key]
+
         d["boltztrap_dir"] = btrap_dir
 
         # trim the output
@@ -156,6 +163,7 @@ class BoltztrapToDBTask(FiretaskBase):
             del d["hall_doping"]
 
         d["scissor"] = bta.intrans["scissor"]
+
 
         # add the structure
         bandstructure_dir = os.getcwd()

--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -340,7 +340,7 @@ class MDFW(Firework):
 
 class BoltztrapFW(Firework):
     def __init__(self, structure, name="boltztrap", db_file=None, parents=None, scissor=0.0,
-                 soc=False, **kwargs):
+                 soc=False, additional_fields=None, **kwargs):
         """
         Run Boltztrap
 
@@ -352,11 +352,13 @@ class BoltztrapFW(Firework):
             scissor (float): if scissor > 0, apply scissor on the band structure so that new
                 band gap = scissor (in eV)
             soc (bool): whether the band structure is calculated with spin-orbit coupling
+            additional_fields (dict): fields added to the document such as user-defined tags or name, ids, etc
             \*\*kwargs: Other kwargs that are passed to Firework.__init__.
         """
+        additional_fields = additional_fields or {}
         t = [CopyVaspOutputs(calc_loc=True, contcar_to_poscar=True),
              RunBoltztrap(scissor=scissor, soc=soc),
-             BoltztrapToDBTask(db_file=db_file),
+             BoltztrapToDBTask(db_file=db_file, additional_fields=additional_fields),
              PassCalcLocs(name=name)]
         super(BoltztrapFW, self).__init__(t, parents=parents, name="{}-{}".format(
             structure.composition.reduced_formula, name), **kwargs)

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -443,6 +443,14 @@ def add_tags(original_wf, tags_list):
         else:
             wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]["tags"] = tags_list
 
+    #TODO: modify get_fws_and_tasks to accept a list of constraints
+    # BoltztrapToDBTask
+    for idx_fw, idx_t in get_fws_and_tasks(original_wf, task_name_constraint="BoltztrapToDBTask"):
+        if "tags" in wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]:
+            wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]["tags"].extend(tags_list)
+        else:
+            wf_dict["fws"][idx_fw]["spec"]["_tasks"][idx_t]["additional_fields"]["tags"] = tags_list
+
     return Workflow.from_dict(wf_dict)
 
 

--- a/atomate/vasp/tests/test_vasp_powerups.py
+++ b/atomate/vasp/tests/test_vasp_powerups.py
@@ -29,6 +29,9 @@ class TestVaspPowerups(unittest.TestCase):
         cls.bs_wf = get_wf(struct_si,
                            "bandstructure.yaml",
                            vis=vis, common_params={"vasp_cmd": "test_VASP"})
+        cls.bsboltz_wf = get_wf(struct_si,
+                           "bandstructure_boltztrap.yaml",
+                           vis=vis)
 
     def _copy_wf(self, wf):
         return Workflow.from_dict(wf.to_dict())
@@ -131,9 +134,27 @@ class TestVaspPowerups(unittest.TestCase):
                 if 'VaspToDbTask' in str(t):
                     self.assertEqual(t["additional_fields"]["tags"], ["b", "c"])
                     found += 1
-
         self.assertEqual(found, 4)
 
+        my_wf = self._copy_wf(self.bsboltz_wf)
+        my_wf = add_tags(my_wf, ["foo", "bar"])
+
+        v_found = 0
+        b_found = 0
+
+        self.assertEqual(my_wf.metadata["tags"], ["foo", "bar"])
+        for fw in my_wf.fws:
+            print(fw.spec["tags"])
+            self.assertEqual(fw.spec["tags"], ["foo", "bar"])
+            for t in fw.tasks:
+                if 'BoltztrapToDBTask' in str(t):
+                    self.assertEqual(t["additional_fields"]["tags"], ["foo", "bar"])
+                    b_found += 1
+                if 'VaspToDbTask' in str(t):
+                    self.assertEqual(t["additional_fields"]["tags"], ["foo", "bar"])
+                    v_found += 1
+        self.assertEqual(b_found, 1)
+        self.assertEqual(v_found, 4)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

1. user can specify some tasks with excluded_tasks argument (a query) so they will be excluded when "materials" collection is being built. Examples of excluded_tasks is {"tags": "test"} or {"tags": {"$all": ["ABCD3", "soc"]}}

In the first example, I wouldn't want the "test" tasks to be included in the final materials collection and in the second one, I don't want the energy values of spin orbit coupling calculations for a specific projects to be included when say energy above hull is calculated.

2. now add_tags also tags Boltztrap jobs so organizing them would be easier later. A unit test is added but I also tested this on a bunch of bandstructure_boltztrap Wflows and the tags show up in the boltztrap collection.