### PR TITLE
Gives users the ability to do elastic tensor calculation in 6 rather than 24 calculations. 

### DIFF
--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -197,6 +197,8 @@ def wf_elastic_constant(structure, c=None):
     if quick_calculation:
         norm_deformations = c.get("norm_deformations", [0.01])
         shear_deformations = c.get("shear_deformations", [0.03])
+
+    
     wf = get_wf_elastic_constant(structure, vasp_cmd=vasp_cmd,
                                  norm_deformations=norm_deformations,
                                  shear_deformations=shear_deformations,

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -190,10 +190,13 @@ def wf_elastic_constant(structure, c=None):
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
     user_kpoints_settings = c.get("user_kpoints_settings", {"grid_density": 7000})
+    optimize_structure = c.get("optimize_structure", True)
     norm_deformations = c.get("norm_deformations", [-0.01, -0.005, 0.005, 0.01])
     shear_deformations = c.get("shear_deformations", [-0.06, -0.03, 0.03, 0.06])
-    optimize_structure = c.get("optimize_structure", True)
-
+    quick_calculation = c.get("quick_calculation", False)
+    if quick_calculation:
+        norm_deformations = c.get("norm_deformations", [0.01])
+        shear_deformations = c.get("shear_deformations", [0.03])
     wf = get_wf_elastic_constant(structure, vasp_cmd=vasp_cmd,
                                  norm_deformations=norm_deformations,
                                  shear_deformations=shear_deformations,


### PR DESCRIPTION
## Summary

This change adds the options for users to easily create an elastic constant workflow that consists of 6 rather than 24 strain-stress calculations. This "quick calculation" workflow does not necessarily produce results consistent with the MP procedure and is not used for MP elastic tensor calculations. As before, if the user specifies the shear and/or norm deformations, those values are uses rather than the defaults. 

* Adds "quick_calculation" as possible key in config dict, default is False
* Default strains are 0.01 normal and 0.03 shear if quick_calculation = True
* Does not change behavior of wf_elastic_constant if user specifies strains
