### PR TITLE
change the name of tag_fws to set_fworker to avoid confusion

### DIFF
--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -216,23 +216,24 @@ def modify_to_soc(original_wf, nbands, structure=None, modify_incar_params=None,
     return Workflow.from_dict(wf_dict)
 
 
-def tag_fws(original_wf, tag, fw_name_constraint=None, task_name_constraint=None):
+def set_spec_fworker(original_wf, fw_queuename, fw_name_constraint=None, task_name_constraint=None):
     """
-    Tags Fireworker(s) of a Workflow; e.g. it can be used to run large-memory jobs on a separate queue.
+    set _fworker spec of Fireworker(s) of a Workflow.
+        It can be used to specify a queue; e.g. run large-memory jobs on a separate queue.
 
     Args:
         original_wf (Workflow):
-        tag (string): user-defined tag to be added under fw.spec._fworker (e.g. "large memory", "big", etc)
-        fw_name_constraint (string): name of the Fireworks to be tagged (all if None is passed)
-        task_name_constraint (string): name of the Firetasks to be tagged (e.g. None or 'RunVasp')
+        fw_queuename (str): user-defined tag to be added under fw.spec._fworker (e.g. "large memory", "big", etc)
+        fw_name_constraint (str): name of the Fireworks to be tagged (all if None is passed)
+        task_name_constraint (str): name of the Firetasks to be tagged (e.g. None or 'RunVasp')
 
     Returns:
-        modified workflow with tagged Fireworkers
+        modified workflow with specified Fireworkers tagged
     """
     wf_dict = original_wf.to_dict()
     for idx_fw, idx_t in get_fws_and_tasks(original_wf, fw_name_constraint=fw_name_constraint,
                                            task_name_constraint=task_name_constraint):
-        wf_dict["fws"][idx_fw]["spec"]["_fworker"] = tag
+        wf_dict["fws"][idx_fw]["spec"]["_fworker"] = fw_queuename
 
     return Workflow.from_dict(wf_dict)
 

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -216,7 +216,7 @@ def modify_to_soc(original_wf, nbands, structure=None, modify_incar_params=None,
     return Workflow.from_dict(wf_dict)
 
 
-def set_spec_fworker(original_wf, fw_queuename, fw_name_constraint=None, task_name_constraint=None):
+def set_fworker(original_wf, fw_queuename, fw_name_constraint=None, task_name_constraint=None):
     """
     set _fworker spec of Fireworker(s) of a Workflow.
         It can be used to specify a queue; e.g. run large-memory jobs on a separate queue.

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -350,27 +350,6 @@ def modify_to_soc(original_wf, nbands, structure=None, modify_incar_params=None,
     return Workflow.from_dict(wf_dict)
 
 
-def tag_fws(original_wf, tag, fw_name_constraint=None):
-    """
-    Tags VASP Fworker(s) of a Workflow; e.g. it can be used to run large-memory jobs on a separate queue
-
-    Args:
-        original_wf (Workflow):
-        tag (string): user-defined tag to be added under fw.spec._fworker (e.g. "large memory", "big", etc)
-        fw_name_constraint (string): name of the fireworks to be modified (all if None is passed)
-
-
-    Returns:
-        modified workflow with tagged Fworkers
-    """
-    wf_dict = original_wf.to_dict()
-    for idx_fw, idx_t in get_fws_and_tasks(original_wf, fw_name_constraint=fw_name_constraint,
-                                           task_name_constraint="RunVasp"):
-        wf_dict["fws"][idx_fw]["spec"]["_fworker"] = tag
-
-    return Workflow.from_dict(wf_dict)
-
-
 def add_small_gap_multiply(original_wf, gap_cutoff, density_multiplier, fw_name_constraint=None):
     """
     In all FWs with specified name constraints, add a 'small_gap_multiply' parameter that


### PR DESCRIPTION
change the name of tag_fws to set_spec_fworker to avoid confusion with the add_tags powerup. Also the variable "tag" is renamed to fw_queuename to better reflect the goal of this powerup. Please feel free to modify these names.

This change is backwards incompatible but I assume it has not been largely used. In my codes, at least, I can correct all the names later.