### PR TITLE
Add import of MPRester to mmwf

### DIFF
--- a/scripts/mmwf
+++ b/scripts/mmwf
@@ -16,7 +16,7 @@ from fireworks import LaunchPad
 from atomate import get_wf_from_spec_dict
 from atomate.vasp.powerups import add_namefile, add_tags
 from atomate.vasp.workflows.presets import core
-from pymatgen import Structure, Lattice
+from pymatgen import Structure, Lattice, MPRester
 from pymatgen.util.testing import PymatgenTest
 
 default_yaml = """fireworks:


### PR DESCRIPTION
## Summary

``mmwf`` requires MPRester to use the `-m` option, but it was not imported from pymatgen. 