### PR TITLE
Fix TestToDB under python2 and cleanup of MongoDB collections from testing

### DIFF
--- a/atomate/common/firetasks/tests/test_parse_outputs.py
+++ b/atomate/common/firetasks/tests/test_parse_outputs.py
@@ -18,6 +18,9 @@ db_dir = os.path.join(module_dir, "..", "..", "test_files")
 
 class TestDrone(AbstractDrone):
 
+    def __init__(self):
+        pass
+
     def assimilate(self, path):
         return {"drone": "Test Drone",
                 "dir_name": "/test",

--- a/atomate/vasp/workflows/tests/test_vasp_workflows.py
+++ b/atomate/vasp/workflows/tests/test_vasp_workflows.py
@@ -34,7 +34,7 @@ ref_dirs_si = {"structure optimization": os.path.join(reference_dir, "Si_structu
              "nscf uniform": os.path.join(reference_dir, "Si_nscf_uniform"),
              "nscf line": os.path.join(reference_dir, "Si_nscf_line")}
 
-DEBUG_MODE = True  # If true, retains the database and output dirs at the end of the test
+DEBUG_MODE = False  # If true, retains the database and output dirs at the end of the test
 VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this command...
 
 


### PR DESCRIPTION
Python2 seems to complain without an __init__ for the test drone. Don't know why. 