### PR TITLE
Fix broken import in atwf

### DIFF
--- a/scripts/atwf
+++ b/scripts/atwf
@@ -13,7 +13,7 @@ import yaml
 from datetime import datetime
 
 from fireworks import LaunchPad
-from atomate import get_wf_from_spec_dict
+from atomate.utils.utils import get_wf_from_spec_dict
 from atomate.vasp.powerups import add_namefile, add_tags
 from atomate.vasp.workflows.presets import core
 from pymatgen import Structure, Lattice, MPRester


### PR DESCRIPTION
Removing imports from `__init__.py` broke atwf. 

As an aside: I agree that `from [module] import *` all over the top level init is not useful, but I think we could put some commonly used things back. Anything user facing should go there, e.g. preset workflows, which become much less tedious to import.