### PR TITLE
Fix travis and misc cleanup of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - source activate test-environment
-  - pip install -r requirements.txt
   - pip install coverage
   - pip install python-coveralls
+  - pip install nose  
 before_script:
   - source activate test-environment
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
+  - pip install -r requirements.txt  
   - pip install coverage
   - pip install python-coveralls
   - pip install nose  

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
   - "3.6"  
 install:
   - sudo apt-get update
-  # copied from conda documentation
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
+  # The following copied from conda documentation.
+  # This is done conditionally because it saves some downloading
+  # if the version is the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
@@ -20,12 +20,12 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
+  - conda create -q -n atomate-test-env python=$TRAVIS_PYTHON_VERSION
+  - source activate atomate-test-env
   - pip install -r requirements.txt
   - pip install -r requirements-optional.txt    
 before_script:
-  - source activate test-environment
+  - source activate atomate-test-env
   - python setup.py develop
 script:
   - nosetests -v atomate --nocapture --with-coverage
@@ -35,5 +35,7 @@ notifications:
   email:
     recipients:
       - kmathew@lbl.gov
+      - ajain@lbl.gov
+      - ongsp@ucsd.edu      
     on_success: change
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,29 @@
 language: python
 services: mongodb
 python:
-  - "3.6"
+  - "2.7"
 install:
-  -  pip install -r requirements.txt
-  -  pip install -q coverage
-  -  pip install -q python-coveralls
+  - sudo apt-get update
+  # copied from conda documentation
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - source activate test-environment
+  - pip install -r requirements.txt
+  - pip install -q coverage
+  - pip install -q python-coveralls
 before_script:
   - python setup.py develop
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ services: mongodb
 python:
   - "2.7"
 install:
-  - pip install -r requirements.txt
-  - pip install coverage
-  - pip install python-coveralls
+  -  travis_wait pip install -q -r requirements.txt
+  -  travis_wait pip install -q coverage
+  -  travis_wait pip install -q python-coveralls
 before_script:
   - python setup.py develop
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 services: mongodb
 python:
   - "2.7"
-  - "3.5"
 install:
   - pip install -r requirements.txt
   - pip install coverage
@@ -10,14 +9,12 @@ install:
 before_script:
   - python setup.py develop
 script:
-  - nosetests --nocapture --with-coverage
+  - nosetests -v --nocapture --with-coverage
 after_success:
   - coveralls
 notifications:
   email:
     recipients:
-      - ajain@lbl.gov
       - kmathew@lbl.gov
-      - ongsp@ucsd.edu
     on_success: change
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - pip install coverage
   - pip install python-coveralls
 before_script:
+  - source activate test-environment
   - python setup.py develop
 script:
   - nosetests -v atomate #--nocapture --with-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - pip install -r requirements.txt
-  - pip install -q coverage
-  - pip install -q python-coveralls
+  - pip install coverage
+  - pip install python-coveralls
 before_script:
   - python setup.py develop
 script:
-  - nosetests -v --nocapture --with-coverage
-after_success:
-  - coveralls
+  - nosetests -v atomate #--nocapture --with-coverage
+#after_success:
+#  - coveralls
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 services: mongodb
 python:
   - "2.7"
+  - "3.6"  
 install:
   - sudo apt-get update
   # copied from conda documentation
@@ -21,17 +22,15 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - pip install -r requirements.txt  
-  - pip install coverage
-  - pip install python-coveralls
-  - pip install nose  
+  - pip install -r requirements.txt
+  - pip install -r requirements-optional.txt    
 before_script:
   - source activate test-environment
   - python setup.py develop
 script:
-  - nosetests -v atomate #--nocapture --with-coverage
-#after_success:
-#  - coveralls
+  - nosetests -v atomate --nocapture --with-coverage
+after_success:
+  - coveralls
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 services: mongodb
 python:
-  - "2.7"
+  - "3.6"
 install:
-  -  travis_wait pip install -q -r requirements.txt
-  -  travis_wait pip install -q coverage
-  -  travis_wait pip install -q python-coveralls
+  -  pip install -r requirements.txt
+  -  pip install -q coverage
+  -  pip install -q python-coveralls
 before_script:
   - python setup.py develop
 script:

--- a/atomate/utils/testing.py
+++ b/atomate/utils/testing.py
@@ -12,6 +12,8 @@ from pymongo import MongoClient
 
 from fireworks import LaunchPad
 
+from pymatgen import SETTINGS
+
 __author__ = 'Kiran Mathew'
 __credits__ = 'Anubhav Jain'
 __email__ = 'kmathew@lbl.gov'
@@ -30,6 +32,11 @@ class AtomateTest(unittest.TestCase):
         Create scratch directory(removes the old one if there is one) and change to it.
         Also initialize launchpad.
         """
+        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
+            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.abspath(os.path.join(MODULE_DIR, "..", "vasp", "test_files"))
+            print('This system is not set up to run VASP jobs. '
+                  'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
+
         self.scratch_dir = os.path.join(MODULE_DIR, "scratch")
         if os.path.exists(self.scratch_dir):
             shutil.rmtree(self.scratch_dir)

--- a/atomate/vasp/firetasks/tests/test_write_vasp.py
+++ b/atomate/vasp/firetasks/tests/test_write_vasp.py
@@ -8,8 +8,8 @@ import unittest
 from fireworks.utilities.fw_serializers import load_object
 
 from atomate.vasp.firetasks.write_inputs import WriteVaspFromIOSet, WriteVaspFromPMGObjects, ModifyIncar
+from atomate.utils.testing import AtomateTest
 
-from pymatgen import SETTINGS
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.io.vasp import Incar, Poscar, Potcar, Kpoints
 from pymatgen.io.vasp.sets import MPRelaxSet
@@ -20,14 +20,9 @@ __email__ = 'ajain@lbl.gov, kmathew@lbl.gov'
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 
 
-class TestWriteVasp(PymatgenTest):
+class TestWriteVasp(PymatgenTest, AtomateTest):
     @classmethod
     def setUpClass(cls):
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "test_files")
-            print('This system is not set up to run VASP jobs. '
-                  'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
-
         cls.struct_si = PymatgenTest.get_structure("Si")
 
         cls.ref_incar = Incar.from_file(
@@ -43,8 +38,7 @@ class TestWriteVasp(PymatgenTest):
                          "KPOINTS"))
         cls.ref_incar_preserve = Incar.from_file(os.path.join(module_dir,
                                                               "..", "..", "test_files",
-                                                              "preserve_incar",
-                                                              "INCAR"))
+                                                              "preserve_incar", "INCAR"))
 
     def setUp(self):
         os.chdir(module_dir)

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -27,8 +27,7 @@ def add_priority(original_wf, root_priority, child_priority=None):
     Args:
         original_wf (Workflow): original WF
         root_priority (int): priority of first (root) job(s)
-        child_priority(int): priority of all child jobs. Defaults to
-                            root_priority
+        child_priority(int): priority of all child jobs. Defaults to root_priority
 
     Returns:
        (Workflow) priority-decorated workflow
@@ -45,13 +44,11 @@ def add_priority(original_wf, root_priority, child_priority=None):
 
 def remove_custodian(original_wf, fw_name_constraint=None):
     """
-    Replaces all tasks with "RunVasp*" (e.g. RunVaspCustodian) to be
-    RunVaspDirect.
+    Replaces all tasks with "RunVasp*" (e.g. RunVaspCustodian) to be RunVaspDirect.
 
     Args:
         original_wf (Workflow): original workflow
-        fw_name_constraint (str): Only apply changes to FWs where fw_name
-            contains this substring.
+        fw_name_constraint (str): Only apply changes to FWs where fw_name contains this substring.
     """
     vasp_fws_and_tasks = get_fws_and_tasks(original_wf, fw_name_constraint=fw_name_constraint,
                                            task_name_constraint="RunVasp")
@@ -63,9 +60,9 @@ def remove_custodian(original_wf, fw_name_constraint=None):
 
 def use_custodian(original_wf, fw_name_constraint=None, custodian_params=None):
     """
-    Replaces all tasks with "RunVasp*" (e.g. RunVaspDirect) to be
-    RunVaspCustodian. Thus, this powerup adds error correction into VASP
-    runs if not originally present and/or modifies the correction behavior.
+    Replaces all tasks with "RunVasp*" (e.g. RunVaspDirect) to be RunVaspCustodian. Thus, this
+    powerup adds error correction into VASP runs if not originally present and/or modifies
+    the correction behavior.
 
     Args:
         original_wf (Workflow): original workflow
@@ -89,12 +86,15 @@ def use_custodian(original_wf, fw_name_constraint=None, custodian_params=None):
 
 def use_no_vasp(original_wf, ref_dirs):
     """
-    Instead of running VASP, does nothing and pass task documents from
-        task.json files in ref_dirs to task database.
+    Instead of running VASP, does nothing and pass task documents from task.json files in ref_dirs
+    to task database.
 
     Args:
         original_wf (Workflow)
         ref_dirs(dict): key=firework name, value=path to the reference vasp calculation directory
+
+    Returns:
+        Workflow
     """
     for idx_fw, fw in enumerate(original_wf.fws):
         for job_type in ref_dirs.keys():
@@ -103,22 +103,23 @@ def use_no_vasp(original_wf, ref_dirs):
                     if "RunVasp" in str(t):
                         original_wf.fws[idx_fw].tasks[idx_t] = RunNoVasp(ref_dir=ref_dirs[job_type])
                     if "VaspToDb" in str(t):
-                        original_wf.fws[idx_fw].tasks[idx_t] = \
-                            JsonToDbTask(db_file=t.get("db_file", None),
-                                         calc_dir=ref_dirs[job_type])
+                        original_wf.fws[idx_fw].tasks[idx_t] = JsonToDbTask(db_file=t.get("db_file", None),
+                                                                            calc_dir=ref_dirs[job_type])
     return original_wf
 
 
 def use_fake_vasp(original_wf, ref_dirs, params_to_check=None):
     """
-    Replaces all tasks with "RunVasp" (e.g. RunVaspDirect) to be
-    RunVaspFake. Thus, we do not actually run VASP but copy
-    pre-determined inputs and outputs.
+    Replaces all tasks with "RunVasp" (e.g. RunVaspDirect) to be RunVaspFake. Thus, we do not
+    actually run VASP but copy pre-determined inputs and outputs.
 
     Args:
         original_wf (Workflow)
         ref_dirs (dict): key=firework name, value=path to the reference vasp calculation directory
         params_to_check (list): optional list of incar parameters to check.
+
+    Returns:
+        Workflow
     """
     if not params_to_check:
         params_to_check = ["ISPIN", "ENCUT", "ISMEAR", "SIGMA", "IBRION", "LORBIT",

--- a/atomate/vasp/test_files/bulk_modulus_wf/3/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/3/task.json
@@ -1,9 +1,4 @@
 {
-    "_id": {
-        "@class": "ObjectId",
-        "@module": "bson.objectid",
-        "oid": "591a2a87ccd43b706cc973d1"
-    },
     "analysis": {
         "delta_volume": 0.0,
         "delta_volume_percent": 0.0,
@@ -893,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 16000051,
-    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 1",
+    "task_id": 18000057,
+    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 1",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/3/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/3/task.json
@@ -888,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 18000057,
-    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 1",
+    "task_id": 19000060,
+    "task_label": "Si-wf_bulk_modulus group: >>e24a191f-efcc-408d-92e7-891dd4cebaa3<< bulk_modulus deformation 1",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/3/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/3/task.json
@@ -893,8 +893,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 14000045,
-    "task_label": "Si-wf_bulk_modulus group: >>d2abce9a-0906-4be4-bfa0-b5f9db15d52c<< bulk_modulus deformation 1",
+    "task_id": 16000051,
+    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 1",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/4/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/4/task.json
@@ -893,8 +893,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 12000052,
-    "task_label": "Si-wf_bulk_modulus group: >>d2abce9a-0906-4be4-bfa0-b5f9db15d52c<< bulk_modulus deformation 2",
+    "task_id": 14000060,
+    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 2",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/4/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/4/task.json
@@ -888,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 16000068,
-    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 2",
+    "task_id": 17000072,
+    "task_label": "Si-wf_bulk_modulus group: >>e24a191f-efcc-408d-92e7-891dd4cebaa3<< bulk_modulus deformation 2",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/4/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/4/task.json
@@ -1,9 +1,4 @@
 {
-    "_id": {
-        "@class": "ObjectId",
-        "@module": "bson.objectid",
-        "oid": "591a2a88ccd43b706cc97406"
-    },
     "analysis": {
         "delta_volume": 0.0,
         "delta_volume_percent": 0.0,
@@ -893,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 14000060,
-    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 2",
+    "task_id": 16000068,
+    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 2",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/5/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/5/task.json
@@ -888,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 16000085,
-    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 3",
+    "task_id": 17000090,
+    "task_label": "Si-wf_bulk_modulus group: >>e24a191f-efcc-408d-92e7-891dd4cebaa3<< bulk_modulus deformation 3",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/5/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/5/task.json
@@ -1,9 +1,4 @@
 {
-    "_id": {
-        "@class": "ObjectId",
-        "@module": "bson.objectid",
-        "oid": "591a2a89ccd43b706cc9743b"
-    },
     "analysis": {
         "delta_volume": 0.0,
         "delta_volume_percent": 0.0,
@@ -893,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 14000075,
-    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 3",
+    "task_id": 16000085,
+    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 3",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/5/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/5/task.json
@@ -893,8 +893,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 12000065,
-    "task_label": "Si-wf_bulk_modulus group: >>d2abce9a-0906-4be4-bfa0-b5f9db15d52c<< bulk_modulus deformation 3",
+    "task_id": 14000075,
+    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 3",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/7/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/7/task.json
@@ -888,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 16000119,
-    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 5",
+    "task_id": 17000126,
+    "task_label": "Si-wf_bulk_modulus group: >>e24a191f-efcc-408d-92e7-891dd4cebaa3<< bulk_modulus deformation 5",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/7/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/7/task.json
@@ -1,9 +1,4 @@
 {
-    "_id": {
-        "@class": "ObjectId",
-        "@module": "bson.objectid",
-        "oid": "591a2a8accd43b706cc974a5"
-    },
     "analysis": {
         "delta_volume": 0.0,
         "delta_volume_percent": 0.0,
@@ -893,8 +888,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 14000105,
-    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 5",
+    "task_id": 16000119,
+    "task_label": "Si-wf_bulk_modulus group: >>3b79027a-7021-44b3-9ba7-79afc4e559e5<< bulk_modulus deformation 5",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/test_files/bulk_modulus_wf/7/task.json
+++ b/atomate/vasp/test_files/bulk_modulus_wf/7/task.json
@@ -893,8 +893,8 @@
         "version": 0.2
     },
     "state": "successful",
-    "task_id": 12000091,
-    "task_label": "Si-wf_bulk_modulus group: >>d2abce9a-0906-4be4-bfa0-b5f9db15d52c<< bulk_modulus deformation 5",
+    "task_id": 14000105,
+    "task_label": "Si-wf_bulk_modulus group: >>ee1db61c-ba65-45a6-92cf-46ce28f8dec2<< bulk_modulus deformation 5",
     "transformations": {},
     "transmuter": {
         "transformation_params": [

--- a/atomate/vasp/tests/test_setup.py
+++ b/atomate/vasp/tests/test_setup.py
@@ -5,7 +5,6 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 import os
 import unittest
 
-from pymatgen import SETTINGS
 from pymatgen import IStructure, Lattice
 from pymatgen.io.vasp import Incar, Poscar, Potcar, Kpoints
 from pymatgen.io.vasp.sets import MPRelaxSet
@@ -19,10 +18,6 @@ module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 class TestSetup(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            raise unittest.SkipTest('This system is not set up to run VASP jobs. '
-                                    'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
-
         coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = Lattice([[3.8401979337, 0.00, 0.00],
                            [1.9200989668, 3.3257101909, 0.00],

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -28,14 +28,13 @@ __email__ = 'ajain@lbl.gov, kmathew@lbl.gov'
 # TODO: @computron: Allow default config dict to be loaded from file -computron
 
 def wf_bandstructure(structure, c=None):
+
     c = c or {}
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
 
-    wf = get_wf(structure, "bandstructure.yaml",
-                vis=MPRelaxSet(structure, force_gamma=True),
-                common_params={"vasp_cmd": vasp_cmd,
-                               "db_file": db_file})
+    wf = get_wf(structure, "bandstructure.yaml", vis=MPRelaxSet(structure, force_gamma=True),
+                common_params={"vasp_cmd": vasp_cmd, "db_file": db_file})
 
     wf = add_common_powerups(wf, c)
 
@@ -53,6 +52,7 @@ def wf_bandstructure(structure, c=None):
 
 
 def wf_bandstructure_plus_hse(structure, gap_only=True, c=None):
+
     c = c or {}
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
@@ -62,10 +62,8 @@ def wf_bandstructure_plus_hse(structure, gap_only=True, c=None):
     else:
         wf_src_name = "bandstructure_hse.yaml"
 
-    wf = get_wf(structure, wf_src_name,
-                vis=MPRelaxSet(structure, force_gamma=True),
-                common_params={"vasp_cmd": vasp_cmd,
-                               "db_file": db_file})
+    wf = get_wf(structure, wf_src_name, vis=MPRelaxSet(structure, force_gamma=True),
+                common_params={"vasp_cmd": vasp_cmd, "db_file": db_file})
 
     wf = add_common_powerups(wf, c)
 
@@ -83,6 +81,7 @@ def wf_bandstructure_plus_hse(structure, gap_only=True, c=None):
 
 
 def wf_bandstructure_plus_boltztrap(structure, c=None):
+
     c = c or {}
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
@@ -92,8 +91,7 @@ def wf_bandstructure_plus_boltztrap(structure, c=None):
         params.append({"vasp_cmd": vasp_cmd, "db_file": db_file})
     params.append({"db_file": db_file})
 
-    wf = get_wf(structure, "bandstructure_boltztrap.yaml",
-                vis=MPRelaxSet(structure, force_gamma=True),
+    wf = get_wf(structure, "bandstructure_boltztrap.yaml", vis=MPRelaxSet(structure, force_gamma=True),
                 params=params)
 
     wf = add_common_powerups(wf, c)
@@ -112,14 +110,13 @@ def wf_bandstructure_plus_boltztrap(structure, c=None):
 
 
 def wf_static(structure, c=None):
+
     c = c or {}
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
 
-    wf = get_wf(structure, "static_only.yaml",
-                vis=MPStaticSet(structure),
-                common_params={"vasp_cmd": vasp_cmd,
-                               "db_file": db_file})
+    wf = get_wf(structure, "static_only.yaml", vis=MPStaticSet(structure),
+                common_params={"vasp_cmd": vasp_cmd, "db_file": db_file})
 
     wf = add_common_powerups(wf, c)
 
@@ -137,10 +134,8 @@ def wf_structure_optimization(structure, c=None):
     user_incar_settings = c.get("USER_INCAR_SETTINGS")
 
     wf = get_wf(structure, "optimize_only.yaml",
-                vis=MPRelaxSet(structure, force_gamma=True,
-                               user_incar_settings=user_incar_settings),
-                common_params={"vasp_cmd": vasp_cmd,
-                               "db_file": db_file})
+                vis=MPRelaxSet(structure, force_gamma=True, user_incar_settings=user_incar_settings),
+                common_params={"vasp_cmd": vasp_cmd, "db_file": db_file})
 
     wf = add_common_powerups(wf, c)
 
@@ -156,10 +151,8 @@ def wf_dielectric_constant(structure, c=None):
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
 
-    wf = get_wf(structure, "dielectric_constant.yaml",
-                vis=MPRelaxSet(structure, force_gamma=True),
-                common_params={"vasp_cmd": vasp_cmd,
-                               "db_file": db_file})
+    wf = get_wf(structure, "dielectric_constant.yaml", vis=MPRelaxSet(structure, force_gamma=True),
+                common_params={"vasp_cmd": vasp_cmd, "db_file": db_file})
 
     wf = add_common_powerups(wf, c)
 
@@ -176,8 +169,7 @@ def wf_dielectric_constant_no_opt(structure, c=None):
     db_file = c.get("DB_FILE", DB_FILE)
 
     wf = get_wf(structure, "dielectric_constant_no_opt.yaml",
-                common_params={"vasp_cmd": vasp_cmd,
-                               "db_file": db_file})
+                common_params={"vasp_cmd": vasp_cmd,  "db_file": db_file})
 
     wf = add_common_powerups(wf, c)
 
@@ -194,8 +186,7 @@ def wf_piezoelectric_constant(structure, c=None):
     db_file = c.get("DB_FILE", DB_FILE)
 
     wf = get_wf(structure, "piezoelectric_constant.yaml",
-                common_params={"vasp_cmd": vasp_cmd,
-                               "db_file": db_file})
+                common_params={"vasp_cmd": vasp_cmd, "db_file": db_file})
 
     wf = add_common_powerups(wf, c)
 
@@ -210,14 +201,11 @@ def wf_elastic_constant(structure, c=None):
     c = c or {}
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
-    # TODO: @kmathew - this is abuse of the config settings. The config settings should just be
-    # high-level things (executive stuff, metadata options) and global (e.g.,
-    # user_kpoints_settings.grid_density is not a global parameter). Note that they are also
-    # typically capitalized. If the user really wants to tune a workflow (e.g. k-mesh) they should
-    # not use the preset workflows which are about trusting the defaults. -computron
-    user_kpoints_settings = c.get("user_kpoints_settings", {"grid_density": 7000})
-    norm_deformations = c.get("norm_deformations", [-0.01, -0.005, 0.005, 0.01])
-    shear_deformations = c.get("shear_deformations", [-0.06, -0.03, 0.03, 0.06])
+
+    user_kpoints_settings = {"grid_density": 7000}
+    norm_deformations = [-0.01, -0.005, 0.005, 0.01]
+    shear_deformations = [-0.06, -0.03, 0.03, 0.06]
+    # not sure about this -matk, will leave it to @montoyj
     optimize_structure = c.get("optimize_structure", True)
 
     wf = get_wf_elastic_constant(structure, vasp_cmd=vasp_cmd,
@@ -225,9 +213,10 @@ def wf_elastic_constant(structure, c=None):
                                  shear_deformations=shear_deformations,
                                  db_file=db_file, user_kpoints_settings=user_kpoints_settings,
                                  optimize_structure=optimize_structure)
-    wf = add_modify_incar(wf, modify_incar_params={"incar_update":{"ENCUT": 700,
-                                                                   "EDIFF": 1e-6,
-                                                                   "LAECHG":False}})
+
+    wf = add_modify_incar(wf, modify_incar_params={"incar_update": {"ENCUT": 700,
+                                                                    "EDIFF": 1e-6,
+                                                                    "LAECHG":False}})
 
     wf = add_common_powerups(wf, c)
 
@@ -250,9 +239,13 @@ def wf_raman_spectra(structure, c=None):
     """
 
     c = c or {}
-    # TODO: @kmathew - See my previous comment about config dict params  -computron
-    wf = get_wf_raman_spectra(structure, modes=c.get("modes", None), step_size=c.get("step_size", 0.005),
-                              vasp_cmd=c.get("vasp_cmd", "vasp"), db_file=c.get("db_file", None))
+    modes = c.get("MODES", None)
+    step_size = c.get("STEP_SIZE", 0.005)
+    vasp_cmd = c.get("VASP_CMD", VASP_CMD)
+    db_file = c.get("DB_FILE", DB_FILE)
+
+    wf = get_wf_raman_spectra(structure, modes=modes, step_size=step_size, vasp_cmd=vasp_cmd,
+                              db_file=db_file)
 
     wf = add_modify_incar(wf, modify_incar_params={"incar_update": {"ENCUT": 600, "EDIFF": 1e-6}},
                           fw_name_constraint="static dielectric")
@@ -278,35 +271,28 @@ def wf_gibbs_free_energy(structure, c=None):
 
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
-
-    # TODO: @kmathew - See my previous comment about config dict params  -computron
-    user_kpoints_settings = c.get("user_kpoints_settings", {"grid_density": 7000})
+    eos = c.get("EOS", "vinet")
+    qha_type = c.get("QHA_TYPE", "debye_model")
+    # min and max temp in K, default setting is to compute the properties at 300K only
+    t_min = c.get("T_MIN", 300.0)
+    t_max = c.get("T_MAX", 300.0)
+    t_step = c.get("T_STEP", 100.0)
+    pressure = c.get("PRESSURE", 0.0)
+    poisson = c.get("POISSON", 0.25)
+    metadata = c.get("METADATA", None)
 
     # 21 deformed structures
-    deformations = c.get("deformations", [(np.identity(3)*(1+x)).tolist()
-                                          for x in np.linspace(-0.1, 0.1, 21)])
-
-    eos = c.get("eos", "vinet")
-    qha_type = c.get("qha_type", "debye_model")
-
-    # TODO: @kmathew - See my previous comment about config dict params. Some of these might
-    # reasonably be in the config dict, e.g. GIBBS.T_MIN, GIBBS.TMAX  -computron
-
-    # min and max temp in K, default setting is to compute the properties at 300K only
-    t_min = c.get("t_min", 300.0)
-    t_max = c.get("t_max", 300.0)
-    t_step = c.get("t_step", 100.0)
-
-    pressure = c.get("pressure", 0.0)
-    poisson = c.get("poisson", 0.25)
-    metadata = c.get("metadata", None)
+    deformations = [(np.identity(3)*(1+x)).tolist() for x in np.linspace(-0.1, 0.1, 21)]
+    user_kpoints_settings = {"grid_density": 7000}
 
     wf = get_wf_gibbs_free_energy(structure, user_kpoints_settings=user_kpoints_settings,
                                   deformations=deformations, vasp_cmd=vasp_cmd, db_file=db_file,
                                   eos=eos, qha_type=qha_type, pressure=pressure, poisson=poisson,
                                   t_min=t_min, t_max=t_max, t_step=t_step, metadata=metadata)
 
-    wf = add_modify_incar(wf, modify_incar_params={"incar_update": {"ENCUT": 600, "EDIFF": 1e-6, "LAECHG": False}})
+    wf = add_modify_incar(wf, modify_incar_params={"incar_update": {"ENCUT": 600,
+                                                                    "EDIFF": 1e-6,
+                                                                    "LAECHG": False}})
 
     wf = add_common_powerups(wf, c)
 
@@ -328,16 +314,14 @@ def wf_bulk_modulus(structure, c=None):
         Workflow
     """
 
-    # TODO: @kmathew - See my previous comment about config dict params.
-    # TODO: @kmathew - see also CAPITALIZATION of config_dict params. I fixed some but
-    # left some for you. -computron
     c = c or {}
-    eos = c.get("eos", "vinet")
+    eos = c.get("EOS", "vinet")
     vasp_cmd = c.get("VASP_CMD", VASP_CMD)
     db_file = c.get("DB_FILE", DB_FILE)
-    user_kpoints_settings = c.get("user_kpoints_settings", {"grid_density": 7000})
-    deformations = c.get("deformations", [(np.identity(3)*(1+x)).tolist()
-                                          for x in np.linspace(-0.05, 0.05, 6)])
+
+    user_kpoints_settings = {"grid_density": 7000}
+    # 6 deformations
+    deformations = [(np.identity(3)*(1+x)).tolist() for x in np.linspace(-0.05, 0.05, 6)]
 
     wf = get_wf_bulk_modulus(structure, eos=eos, user_kpoints_settings=user_kpoints_settings,
                              deformations=deformations, vasp_cmd=vasp_cmd, db_file=db_file)
@@ -364,16 +348,14 @@ def wf_thermal_expansion(structure, c=None):
         Workflow
     """
     c = c or {}
-    # TODO: @kmathew - See my previous comment about config dict params.
-    # TODO: @kmathew - see also CAPITALIZATION of config_dict params. I fixed some but
-    # left some for you. -computron
-    eos = c.get("eos", "vinet")
-    vasp_cmd = c.get("vasp_cmd", VASP_CMD)
-    db_file = c.get("db_file", DB_FILE)
-    user_kpoints_settings = c.get("user_kpoints_settings", {"grid_density": 7000})
-    deformations = c.get("deformations", [(np.identity(3)*(1+x)).tolist()
-                                          for x in np.linspace(-0.1, 0.1, 10)])
-    pressure = c.get("pressure", 0.0)
+    eos = c.get("EOS", "vinet")
+    vasp_cmd = c.get("VASP_CMD", VASP_CMD)
+    db_file = c.get("DB_FILE", DB_FILE)
+    pressure = c.get("PRESSURE", 0.0)
+
+    user_kpoints_settings = {"grid_density": 7000}
+    # 10 deformations
+    deformations = [(np.identity(3)*(1+x)).tolist() for x in np.linspace(-0.1, 0.1, 10)]
 
     wf = get_wf_thermal_expansion(structure, user_kpoints_settings=user_kpoints_settings,
                                   deformations=deformations, vasp_cmd=vasp_cmd, db_file=db_file,

--- a/atomate/vasp/workflows/tests/test_adsorbate_workflow.py
+++ b/atomate/vasp/workflows/tests/test_adsorbate_workflow.py
@@ -3,17 +3,16 @@
 from __future__ import division, print_function, unicode_literals, absolute_import
 
 import os
-import shutil
 import unittest
 
-from fireworks import LaunchPad, FWorker
+from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
 
 from atomate.vasp.powerups import use_fake_vasp
 from atomate.vasp.workflows.base.adsorption import get_wf_surface
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import SETTINGS, Structure, Molecule, Lattice
+from pymatgen import Structure, Molecule, Lattice
 from pymatgen.core.surface import generate_all_slabs
 
 __author__ = 'Kiran Mathew, Joseph Montoya'
@@ -31,10 +30,6 @@ class TestAdsorptionWorkflow(AtomateTest):
 
     def setUp(self):
         super(TestAdsorptionWorkflow, self).setUp()
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "..", "..", "test_files")
-            print('This system is not set up to run VASP jobs. '
-                  'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
 
         self.struct_ir = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3.875728), ["Ir"], [[0, 0, 0]])
         sgp = {"max_index": 1, "min_slab_size": 7.0, "min_vacuum_size": 20.0}

--- a/atomate/vasp/workflows/tests/test_adsorbate_workflow.py
+++ b/atomate/vasp/workflows/tests/test_adsorbate_workflow.py
@@ -28,44 +28,21 @@ VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this c
 
 
 class TestAdsorptionWorkflow(AtomateTest):
-    @classmethod
-    def setUpClass(cls):
+
+    def setUp(self):
+        super(TestAdsorptionWorkflow, self).setUp()
         if not SETTINGS.get("PMG_VASP_PSP_DIR"):
             SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "..", "..", "test_files")
             print('This system is not set up to run VASP jobs. '
                   'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
 
-        cls.struct_ir = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3.875728), ["Ir"], [[0, 0, 0]])
-        cls.scratch_dir = os.path.join(module_dir, "scratch")
+        self.struct_ir = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3.875728), ["Ir"], [[0, 0, 0]])
         sgp = {"max_index": 1, "min_slab_size": 7.0, "min_vacuum_size": 20.0}
-        slabs = generate_all_slabs(cls.struct_ir, **sgp)
+        slabs = generate_all_slabs(self.struct_ir, **sgp)
         slabs = [slab for slab in slabs if slab.miller_index==(1, 0, 0)]
         sgp.pop("max_index")
-        cls.wf_1 = get_wf_surface(slabs, [Molecule("H", [[0, 0, 0]])], cls.struct_ir, sgp,
+        self.wf_1 = get_wf_surface(slabs, [Molecule("H", [[0, 0, 0]])], self.struct_ir, sgp,
                                   db_file=os.path.join(db_dir, "db.json"))
-
-    def setUp(self):
-        if os.path.exists(self.scratch_dir):
-            shutil.rmtree(self.scratch_dir)
-        os.makedirs(self.scratch_dir)
-        os.chdir(self.scratch_dir)
-        try:
-            self.lp = LaunchPad.from_file(os.path.join(db_dir, "my_launchpad.yaml"))
-            self.lp.reset("", require_password=False)
-        except:
-            raise unittest.SkipTest(
-                'Cannot connect to MongoDB! Is the database server running? '
-                'Are the credentials correct?')
-
-    def tearDown(self):
-        if not DEBUG_MODE:
-            shutil.rmtree(self.scratch_dir)
-            self.lp.reset("", require_password=False)
-            db = self.get_task_database()
-            for coll in db.collection_names():
-                if coll != "system.indexes":
-                    db[coll].drop()
-            os.chdir(module_dir)
 
     def _simulate_vasprun(self, wf):
         reference_dir = os.path.abspath(os.path.join(ref_dir, "adsorbate_wf"))

--- a/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
+++ b/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
@@ -47,18 +47,17 @@ class TestBulkModulusWorkflow(AtomateTest):
     2. once task.json is present, VaspRun can be skipped where task.json is
         available and their "inputs" and "outputs" folders can be removed
     """
-    @classmethod
-    def setUpClass(cls):
+
+    def setUp(self):
+        super(TestBulkModulusWorkflow, self).setUp()
         if not SETTINGS.get("PMG_VASP_PSP_DIR"):
             SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "reference_files")
             print('This system is not set up to run VASP jobs. '
                   'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
 
-        cls.scratch_dir = os.path.join(module_dir, "scratch")
-        cls.wf_config = {"deformations": deformations,
+        self.wf_config = {"deformations": deformations,
                             "vasp_cmd": ">>vasp_cmd<<", "db_file": ">>db_file<<"}
-
-        cls.wf = wf_bulk_modulus(struct_si, cls.wf_config)
+        self.wf = wf_bulk_modulus(struct_si, self.wf_config)
 
     def _simulate_vasprun(self, wf):
         no_vasp_ref_dirs = {}
@@ -70,7 +69,7 @@ class TestBulkModulusWorkflow(AtomateTest):
             else:
                 no_vasp_ref_dirs["bulk_modulus deformation {}".format(i-2)] = os.path.join(reference_dir, str(i))
 
-        fake_vasp_ref_dirs["structure optimization"] =  os.path.join(reference_dir, "1")
+        fake_vasp_ref_dirs["structure optimization"] = os.path.join(reference_dir, "1")
         new_wf = use_no_vasp(wf, no_vasp_ref_dirs)
         return use_fake_vasp(new_wf, fake_vasp_ref_dirs, params_to_check=["ENCUT"])
 

--- a/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
+++ b/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
@@ -90,7 +90,6 @@ class TestBulkModulusWorkflow(AtomateTest):
             self.relaxed_struct_si = d["calcs_reversed"][0]["output"]["structure"]
 
         elif mode in ["bulk_modulus deformation 0"]:
-
             for i, l in enumerate(["a", "b", "c"]):
                 self.assertAlmostEqual(d["input"]["structure"]["lattice"][l],
                 self.relaxed_struct_si["lattice"][l]* (deformations[0][i][i]), 2)
@@ -121,7 +120,8 @@ class TestBulkModulusWorkflow(AtomateTest):
                     new_fw = self.lp.fireworks.find_one(
                         {"name": {"$regex": "bulk_modulus deformation {}".format(i - 2)}})
 
-                    # the fw tag (inluded in "name") is important in pulling tasks in the last FW in wf_bulk_modulus
+                    # the fw tag (inluded in "name") is important in pulling tasks in the last FW
+                    # in wf_bulk_modulus
                     d["task_label"] = new_fw["name"]
                     d["task_id"] += i + 1000000  # to avoid duplicate task_id
 
@@ -129,8 +129,8 @@ class TestBulkModulusWorkflow(AtomateTest):
                     json.dump(d, fp, sort_keys=True, indent=4, ensure_ascii=False, cls=MontyEncoder)
 
             elif not os.path.exists(os.path.join(reference_dir, str(i), "inputs")):
-                raise IOError("neither {} nor {} are present in {}".format("inputs",
-                    self.task_file, os.path.join(reference_dir, str(i))))
+                raise IOError("neither {} nor {} are present in {}".format(
+                    "inputs", self.task_file, os.path.join(reference_dir, str(i))))
 
     def write_task_docs(self):
         # this step needs to be run once: once task.json is present, remove the inputs/outputs folders

--- a/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
+++ b/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
@@ -4,13 +4,12 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 
 import json
 import os
-import shutil
 import unittest
 
 import numpy as np
 from monty.json import MontyEncoder
 
-from fireworks import LaunchPad, FWorker
+from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
 
 from atomate.vasp.powerups import use_fake_vasp, use_no_vasp
@@ -21,7 +20,6 @@ from pymatgen import SETTINGS, Structure
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
-
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 db_dir = os.path.join(module_dir, "..", "..", "..", "common", "test_files")
 reference_dir = os.path.join(module_dir, "..", "..", "test_files", "bulk_modulus_wf")
@@ -30,13 +28,10 @@ DEBUG_MODE = False  # If True, retains the database and output dirs at the end o
 VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this command...
 _write_task_docs = False # Test developer option: defaults to False, need to be True only once
 
-struct_si = PymatgenTest.get_structure("Si")
-ndeformations = 6
-deformations = [(np.identity(3)*(1+x)).tolist() for x in np.linspace(-0.05, 0.05, ndeformations)]
-
 
 class TestBulkModulusWorkflow(AtomateTest):
-    """This test will either actually run VASP (if VASP_CMD is set) or artificially pass on outputs
+    """
+    This test will either actually run VASP (if VASP_CMD is set) or artificially pass on outputs
     (if not VASP_CMD) and test the whole bulk modulus workflow and its implementation and outputs
     for an example calculation for silicon.
 
@@ -50,24 +45,29 @@ class TestBulkModulusWorkflow(AtomateTest):
 
     def setUp(self):
         super(TestBulkModulusWorkflow, self).setUp()
+        
         if not SETTINGS.get("PMG_VASP_PSP_DIR"):
             SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "reference_files")
             print('This system is not set up to run VASP jobs. '
                   'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
 
-        self.wf_config = {"deformations": deformations,
+        self.struct_si = PymatgenTest.get_structure("Si")
+        self.ndeformations = 6
+        self.deformations = [(np.identity(3) * (1 + x)).tolist() for x in
+                             np.linspace(-0.05, 0.05, self.ndeformations)]
+        self.wf_config = {"deformations": self.deformations,
                             "vasp_cmd": ">>vasp_cmd<<", "db_file": ">>db_file<<"}
-        self.wf = wf_bulk_modulus(struct_si, self.wf_config)
+        self.wf = wf_bulk_modulus(self.struct_si, self.wf_config)
 
     def _simulate_vasprun(self, wf):
         no_vasp_ref_dirs = {}
         fake_vasp_ref_dirs = {}
-        for i in range(2, ndeformations+2):
+        for i in range(2, self.ndeformations+2):
             if os.path.exists(os.path.join(reference_dir, str(i), "inputs")):
                 if not VASP_CMD:
                     fake_vasp_ref_dirs["bulk_modulus deformation {}".format(i-2)] = os.path.join(reference_dir, str(i))
             else:
-                no_vasp_ref_dirs["bulk_modulus deformation {}".format(i-2)] = os.path.join(reference_dir, str(i))
+                no_vasp_ref_dirs["bulk_modulus deformation {}".format(i-2)] = os.path.join(self.scratch_dir, str(i))
 
         fake_vasp_ref_dirs["structure optimization"] = os.path.join(reference_dir, "1")
         new_wf = use_no_vasp(wf, no_vasp_ref_dirs)
@@ -92,28 +92,28 @@ class TestBulkModulusWorkflow(AtomateTest):
         elif mode in ["bulk_modulus deformation 0"]:
             for i, l in enumerate(["a", "b", "c"]):
                 self.assertAlmostEqual(d["input"]["structure"]["lattice"][l],
-                self.relaxed_struct_si["lattice"][l]* (deformations[0][i][i]), 2)
+                self.relaxed_struct_si["lattice"][l]* (self.deformations[0][i][i]), 2)
             stress = d["calcs_reversed"][0]["output"]["ionic_steps"][-1]["stress"]
             np.testing.assert_allclose(stress, np.diag([189.19, 189.19, 189.19]), atol=1e-2)
 
         elif mode in ["bulk_modulus deformation 4"]:
             for i, l in enumerate(["a", "b", "c"]):
                 self.assertAlmostEqual(d["input"]["structure"]["lattice"][l],
-                        self.relaxed_struct_si["lattice"][l] * (deformations[4][i][i]), 2)
+                        self.relaxed_struct_si["lattice"][l] * (self.deformations[4][i][i]), 2)
             stress = d["calcs_reversed"][0]["output"]["ionic_steps"][-1]["stress"]
             np.testing.assert_allclose(stress, np.diag([-65.56, -65.56, -65.56]), atol=1e-2)
 
         elif mode in ["fit equation of state"]:
             self.assertAlmostEqual(d["bulk_modulus"], 88.90, places=2)
             self.assertEqual(len(d["all_task_ids"]), 7)
-            self.assertEqual(len(d["energies"]), ndeformations)
-            self.assertEqual(len(d["volumes"]), ndeformations)
+            self.assertEqual(len(d["energies"]), self.ndeformations)
+            self.assertEqual(len(d["volumes"]), self.ndeformations)
             s = SpacegroupAnalyzer(Structure.from_dict(d["structure"])).get_conventional_standard_structure()
             self.assertAlmostEqual(s.lattice.c, 5.468, places=3)
 
     def setup_task_docs(self):
         self.task_file = "task.json"
-        for i in range(2, ndeformations+2):
+        for i in range(2, self.ndeformations+2):
             if os.path.exists(os.path.join(reference_dir, str(i), self.task_file)):
                 with open(os.path.join(reference_dir, str(i), self.task_file)) as fp:
                     d = json.load(fp)
@@ -125,7 +125,8 @@ class TestBulkModulusWorkflow(AtomateTest):
                     d["task_label"] = new_fw["name"]
                     d["task_id"] += i + 1000000  # to avoid duplicate task_id
 
-                with open(os.path.join(reference_dir, str(i), "task.json"), 'w') as fp:
+                os.makedirs(os.path.join(self.scratch_dir, str(i)))
+                with open(os.path.join(self.scratch_dir, str(i), "task.json"), 'w') as fp:
                     json.dump(d, fp, sort_keys=True, indent=4, ensure_ascii=False, cls=MontyEncoder)
 
             elif not os.path.exists(os.path.join(reference_dir, str(i), "inputs")):
@@ -134,7 +135,7 @@ class TestBulkModulusWorkflow(AtomateTest):
 
     def write_task_docs(self):
         # this step needs to be run once: once task.json is present, remove the inputs/outputs folders
-        for i in range(2, ndeformations + 2):
+        for i in range(2, self.ndeformations + 2):
             # not to unnecessarily override available task.json
             if not os.path.exists(os.path.join(reference_dir, str(i), "task.json")):
                 d = self.get_task_collection().find_one(
@@ -151,7 +152,7 @@ class TestBulkModulusWorkflow(AtomateTest):
 
     def test_wf(self):
         self.wf = self._simulate_vasprun(self.wf)
-        self.assertEqual(len(self.wf.fws), ndeformations+2)
+        self.assertEqual(len(self.wf.fws), self.ndeformations+2)
 
         defo_vis = [fw.tasks[2]['vasp_input_set'] for fw in self.wf.fws if "deform" in fw.name]
         assert all([vis.user_incar_settings['NSW'] == 99 for vis in defo_vis])

--- a/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
+++ b/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
@@ -16,7 +16,7 @@ from atomate.vasp.powerups import use_fake_vasp, use_no_vasp
 from atomate.vasp.workflows.presets.core import wf_bulk_modulus
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import SETTINGS, Structure
+from pymatgen import Structure
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
@@ -45,12 +45,6 @@ class TestBulkModulusWorkflow(AtomateTest):
 
     def setUp(self):
         super(TestBulkModulusWorkflow, self).setUp()
-        
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "reference_files")
-            print('This system is not set up to run VASP jobs. '
-                  'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
-
         self.struct_si = PymatgenTest.get_structure("Si")
         self.ndeformations = 6
         self.deformations = [(np.identity(3) * (1 + x)).tolist() for x in

--- a/atomate/vasp/workflows/tests/test_elastic_workflow.py
+++ b/atomate/vasp/workflows/tests/test_elastic_workflow.py
@@ -15,7 +15,6 @@ from atomate.vasp.workflows.presets.core import wf_elastic_constant
 from atomate.vasp.workflows.base.elastic import get_wf_elastic_constant
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import SETTINGS
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
@@ -34,11 +33,6 @@ class TestElasticWorkflow(AtomateTest):
 
     def setUp(self):
         super(TestElasticWorkflow, self).setUp()
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "..", "..", "test_files")
-            print('This system is not set up to run VASP jobs. '
-                  'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
-
         self.struct_si = SpacegroupAnalyzer(
                 PymatgenTest.get_structure("Si")).get_conventional_standard_structure()
         self.elastic_config = {"norm_deformations":[0.01],

--- a/atomate/vasp/workflows/tests/test_elastic_workflow.py
+++ b/atomate/vasp/workflows/tests/test_elastic_workflow.py
@@ -32,24 +32,23 @@ VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this c
 
 class TestElasticWorkflow(AtomateTest):
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
+        super(TestElasticWorkflow, self).setUp()
         if not SETTINGS.get("PMG_VASP_PSP_DIR"):
             SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "..", "..", "test_files")
             print('This system is not set up to run VASP jobs. '
                   'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
 
-        cls.struct_si = SpacegroupAnalyzer(
+        self.struct_si = SpacegroupAnalyzer(
                 PymatgenTest.get_structure("Si")).get_conventional_standard_structure()
-        cls.scratch_dir = os.path.join(module_dir, "scratch")
-        cls.elastic_config = {"norm_deformations":[0.01],
+        self.elastic_config = {"norm_deformations":[0.01],
                               "shear_deformations":[0.03],
                               "vasp_cmd": ">>vasp_cmd<<", "db_file": ">>db_file<<"}
-        cls.wf = wf_elastic_constant(cls.struct_si, cls.elastic_config)
-        cls.wf_noopt = get_wf_elastic_constant(cls.struct_si, norm_deformations=[0.01], 
+        self.wf = wf_elastic_constant(self.struct_si, self.elastic_config)
+        self.wf_noopt = get_wf_elastic_constant(self.struct_si, norm_deformations=[0.01],
                 shear_deformations=[0.03], optimize_structure=False)
         mip = {"incar_update": {"ENCUT": 700}}
-        cls.wf_noopt = add_modify_incar(cls.wf_noopt, modify_incar_params=mip)
+        self.wf_noopt = add_modify_incar(self.wf_noopt, modify_incar_params=mip)
 
     def _simulate_vasprun(self, wf):
         reference_dir = os.path.abspath(os.path.join(ref_dir, "elastic_wf"))

--- a/atomate/vasp/workflows/tests/test_neb_workflow.py
+++ b/atomate/vasp/workflows/tests/test_neb_workflow.py
@@ -14,7 +14,6 @@ from atomate.vasp.powerups import use_fake_vasp
 from atomate.vasp.workflows.presets.core import wf_nudged_elastic_band
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import SETTINGS
 from pymatgen.core import Structure
 from pymatgen.util.testing import PymatgenTest
 
@@ -43,15 +42,7 @@ class TestNudgedElasticBandWorkflow(AtomateTest):
         1) Basic check for pymatgen configurations.
         2) Setup all test workflow.
         """
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests",
-                                                        "..", "..", "test_files")
-            print('This system is not set up to run VASP jobs. '
-                  'Please set PMG_VASP_PSP_DIR variable in '
-                  'your ~/.pmgrc.yaml file.')
-
         super(TestNudgedElasticBandWorkflow, self).setUp()
-
         # Structures used for test:
         parent = PymatgenTest.get_structure("Li2O")
         parent.remove_oxidation_states()

--- a/atomate/vasp/workflows/tests/test_raman_workflow.py
+++ b/atomate/vasp/workflows/tests/test_raman_workflow.py
@@ -14,7 +14,6 @@ from atomate.vasp.powerups import use_fake_vasp
 from atomate.vasp.workflows.presets.core import wf_raman_spectra
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import SETTINGS
 from pymatgen.util.testing import PymatgenTest
 
 __author__ = 'Kiran Mathew'
@@ -32,11 +31,6 @@ class TestRamanWorkflow(AtomateTest):
 
     def setUp(self):
         super(TestRamanWorkflow, self).setUp()
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "..", "..", "test_files")
-            print('This system is not set up to run VASP jobs. '
-                  'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
-
         self.struct_si = PymatgenTest.get_structure("Si")
         self.raman_config = {"modes": [0, 1], "step_size": 0.005,
                             "vasp_cmd": ">>vasp_cmd<<", "db_file": ">>db_file<<"}

--- a/atomate/vasp/workflows/tests/test_raman_workflow.py
+++ b/atomate/vasp/workflows/tests/test_raman_workflow.py
@@ -30,17 +30,17 @@ VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this c
 
 class TestRamanWorkflow(AtomateTest):
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
+        super(TestRamanWorkflow, self).setUp()
         if not SETTINGS.get("PMG_VASP_PSP_DIR"):
             SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "tests", "..", "..", "test_files")
             print('This system is not set up to run VASP jobs. '
                   'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
 
-        cls.struct_si = PymatgenTest.get_structure("Si")
-        cls.raman_config = {"modes": [0, 1], "step_size": 0.005,
+        self.struct_si = PymatgenTest.get_structure("Si")
+        self.raman_config = {"modes": [0, 1], "step_size": 0.005,
                             "vasp_cmd": ">>vasp_cmd<<", "db_file": ">>db_file<<"}
-        cls.wf = wf_raman_spectra(cls.struct_si, cls.raman_config)
+        self.wf = wf_raman_spectra(self.struct_si, self.raman_config)
 
     def _simulate_vasprun(self, wf):
         reference_dir = os.path.abspath(os.path.join(ref_dir, "raman_wf"))

--- a/atomate/vasp/workflows/tests/test_vasp_workflows.py
+++ b/atomate/vasp/workflows/tests/test_vasp_workflows.py
@@ -18,7 +18,6 @@ from atomate.vasp.powerups import use_custodian, add_namefile, use_fake_vasp, ad
 from atomate.vasp.workflows.base.core import get_wf
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import SETTINGS
 from pymatgen.io.vasp.sets import MPRelaxSet
 from pymatgen.util.testing import PymatgenTest
 
@@ -42,11 +41,6 @@ class TestVaspWorkflows(AtomateTest):
 
     def setUp(self):
         super(TestVaspWorkflows, self).setUp()
-        # TODO: update this for the latest pymatgen...
-        if not SETTINGS.get("PMG_VASP_PSP_DIR"):
-            SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "test_files")
-            print('This system is not set up to run VASP jobs. '
-                  'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
         self.struct_si = PymatgenTest.get_structure("Si")
 
     def _check_run(self, d, mode):

--- a/atomate/vasp/workflows/tests/test_vasp_workflows.py
+++ b/atomate/vasp/workflows/tests/test_vasp_workflows.py
@@ -39,17 +39,15 @@ VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this c
 
 
 class TestVaspWorkflows(AtomateTest):
-    @classmethod
-    def setUpClass(cls):
+
+    def setUp(self):
+        super(TestVaspWorkflows, self).setUp()
         # TODO: update this for the latest pymatgen...
         if not SETTINGS.get("PMG_VASP_PSP_DIR"):
             SETTINGS["PMG_VASP_PSP_DIR"] = os.path.join(module_dir, "..", "..", "test_files")
             print('This system is not set up to run VASP jobs. '
                   'Please set PMG_VASP_PSP_DIR variable in your ~/.pmgrc.yaml file.')
-
-        cls.struct_si = PymatgenTest.get_structure("Si")
-
-        cls.scratch_dir = os.path.join(module_dir, "scratch")
+        self.struct_si = PymatgenTest.get_structure("Si")
 
     def _check_run(self, d, mode):
         if mode not in ["structure optimization", "static", "nscf uniform", "nscf line"]:

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,3 @@
+nose==1.3.7
+coverage==4.4.1
+coveralls==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+numpy==1.12.1
+scipy==0.19.0
 FireWorks==1.4.3
 pymatgen==4.7.7
 pymatgen-db==0.6.5

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
                         'phonons': ['phonopy>=1.10.8']},
         classifiers=['Programming Language :: Python :: 2.7',
                      "Programming Language :: Python :: 3",
-                     "Programming Language :: Python :: 3.5",
+                     "Programming Language :: Python :: 3.6",
                      'Development Status :: 4 - Beta',
                      'Intended Audience :: Science/Research',
                      'Intended Audience :: System Administrators',


### PR DESCRIPTION
* Testing with python 2.7 fails on travis(3 is fine) due to numpy/scipy installation failure caused by some lapack issues. So i set up travis with conda(nothing fancy, straight up copied sample config from conda doc with minor customizations) for both 2.7 and 3.6
* All tests except one pass for both 2.7 and 3.6. The only test that keep failing is the bulk modulus wflow test(some pymongo issue on travis) but it passes on my machine(both 2.7 and 3.6).  @albalu could you take a look at the bulk modulus tests?  Also i noticed that in the bulk modulus test some of the refernce files are getting modified?!