### PR TITLE
Fixed dieletric_constant_no_opt

### DIFF
--- a/atomate/vasp/workflows/base/library/dielectric_constant_no_opt.yaml
+++ b/atomate/vasp/workflows/base/library/dielectric_constant_no_opt.yaml
@@ -1,3 +1,5 @@
 # static dielectric constant
 fireworks:
 - fw: atomate.vasp.fireworks.core.LepsFW
+  params:
+    copy_vasp_outputs: False


### PR DESCRIPTION
Previously yaml definition didn't include copy_vasp_outputs which is set by default to True in the LepsFW. This just ensures it gets set to false since there is no previous firework. 