### PR TITLE
DO NOT MERGE: pasting wfs

### DIFF
--- a/atomate/utils/utils.py
+++ b/atomate/utils/utils.py
@@ -313,8 +313,6 @@ def paste_wfs(wf_1, wf_2, parent_fw_ids=None, glue_tasks_1=[],
     """
     if parent_fw_ids is None:
         parent_fw_ids = wf_1.leaf_fw_ids
-    if child_fw_ids is None:
-        child_fw_ids = wf_1.root_fw_ids
         
     if isinstance(glue_tasks_1, list):
         glue_tasks_1 = {k: glue_tasks_1 for k in parent_fw_ids}


### PR DESCRIPTION
## Paste wf with "glue tasks"

@matk86 and I were talking about the new design of the elastic workflow and how it's preferable to have workflows be subunits that accomplish one thing (e. g. between the elastic and optimization wfs).  In the current implementation, it's a little wonky because a user has to specify the `copy_vasp_outputs` keyword as `False` or `True` separately from connecting the workflows (and if specified incorrectly, the workflow breaks, even if the user connecting them presumably means they want the results from the first workflow passed to the second).  Kiran suggested that a functionality that connects the workflows and _adds the appropriate glue_tasks_ to the parents/children that connect the workflows would be useful in making these connections without having to specify the appropriate keywords in the workflow constructor in order to ensure that the connected workflows work properly.

I've put a rough implementation in this PR, but I wanted to get feedback about where it should go.  It might be general enough to add to Fireworks proper (e. g. to `Workflow.append_wf`), but the design principle of "glue_tasks" is something that might be appropriate to keep in atomate.  If it should stay in atomate, I'm not sure whether it should stay in utils or be somewhere else.  When that's determined, I'll write a unit test.