### PR TITLE
add the ability to copy additional files in StaticFW

### DIFF
--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -66,23 +66,25 @@ class OptimizeFW(Firework):
 
 class StaticFW(Firework):
     def __init__(self, structure, name="static", vasp_input_set=None, vasp_cmd="vasp",
-                 prev_calc_loc=True, db_file=None, parents=None, **kwargs):
+                 prev_calc_loc=True, db_file=None, parents=None, additional_files=None, **kwargs):
         """
         Standard static calculation Firework - either from a previous location or from a structure.
 
         Args:
-            structure (Structure): Input structure. Note that for prev_calc_loc jobs, the structure 
-                is only used to set the name of the FW and any structure with the same composition 
+            structure (Structure): Input structure. Note that for prev_calc_loc jobs, the structure
+                is only used to set the name of the FW and any structure with the same composition
                 can be used.
             name (str): Name for the Firework.
             vasp_input_set (VaspInputSet): input set to use (for jobs w/no parents)
                 Defaults to MPStaticSet() if None.
             vasp_cmd (str): Command to run vasp.
-            prev_calc_loc (bool or str): If true (default), copies outputs from previous calc. If 
+            prev_calc_loc (bool or str): If true (default), copies outputs from previous calc. If
                 a str value, grabs a previous calculation output by name. If False/None, will create
                 new static calculation using the provided structure.
             db_file (str): Path to file specifying db credentials.
             parents (Firework): Parents of this particular Firework. FW or list of FWS.
+            additional_files ([str]): additional files to copy,
+            e.g. ["CHGCAR", "WAVECAR"]. Use $ALL if you just want to copy everything
             \*\*kwargs: Other kwargs that are passed to Firework.__init__.
         """
 
@@ -94,7 +96,8 @@ class StaticFW(Firework):
 
         if parents:
             if prev_calc_loc:
-                t.append(CopyVaspOutputs(calc_loc=prev_calc_loc, contcar_to_poscar=True))
+                t.append(CopyVaspOutputs(calc_loc=prev_calc_loc, contcar_to_poscar=True,
+                                         additional_files=additional_files))
             t.append(WriteVaspStaticFromPrev())
         else:
             vasp_input_set = vasp_input_set or MPStaticSet(structure)


### PR DESCRIPTION
## Summary

I wanted to define a new workflow where WAVECAR is also copied from the previous static step. I needed to add the argument additional_files to StaticFW to enable that. This change is backwards compatible as additional_files defaults to None.

Also, I had to change CopyVaspOutputs to what I think is simpler and fixed a bug. The bug: in the previous version, if contcar_to_poscar and "CONTCAR" not in files_to_copy, it would raise an error when files_to_copy was still None (if "$ALL" in additional_files).

I also tested this via the new workflow that I defined.
