### PR TITLE
Small change to VaspDrone to pick up volumetric data metadata

### DIFF
--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -319,7 +319,7 @@ class VaspDrone(AbstractDrone):
         d["output"]["is_metal"] = bs.is_metal()
         d["task"] = {"type": taskname, "name": taskname}
 
-        d["datafiles"] = self.process_raw_data(dir_name, taskname=taskname)
+        d["output_file_paths"] = self.process_raw_data(dir_name, taskname=taskname)
 
         if hasattr(vrun, "force_constants"):
             # phonon-dfpt

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -319,11 +319,30 @@ class VaspDrone(AbstractDrone):
         d["output"]["is_metal"] = bs.is_metal()
         d["task"] = {"type": taskname, "name": taskname}
 
+        d["volumetric_data"] = self.process_volumetric(dir_name, taskname=taskname)
+
         if hasattr(vrun, "force_constants"):
             # phonon-dfpt
             d["output"]["force_constants"] = vrun.force_constants.tolist()
             d["output"]["normalmode_eigenvals"] = vrun.normalmode_eigenvals.tolist()
             d["output"]["normalmode_eigenvecs"] = vrun.normalmode_eigenvecs.tolist()
+        return d
+
+    def process_volumetric(self, dir_name, taskname="standard"):
+        """
+        It is useful to store what volumetric data has been
+        calculated.
+
+        :param dir_name: directory to search
+        :param taskname: taskname, e.g. "relax1"
+        :return: dict of files present
+        """
+        d = {}
+        possible_files = ('CHGCAR', 'LOCPOT', 'AECCAR0', 'AECCAR1', 'AECCAR2', 'ELFCAR')
+        for f in possible_files:
+            files = self.filter_files(dir_name, file_pattern=f)
+            if taskname in files:
+                d[f.lower()] = files[taskname]
         return d
 
     @staticmethod

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -319,7 +319,7 @@ class VaspDrone(AbstractDrone):
         d["output"]["is_metal"] = bs.is_metal()
         d["task"] = {"type": taskname, "name": taskname}
 
-        d["volumetric_data"] = self.process_volumetric(dir_name, taskname=taskname)
+        d["datafiles"] = self.process_raw_data(dir_name, taskname=taskname)
 
         if hasattr(vrun, "force_constants"):
             # phonon-dfpt
@@ -328,17 +328,18 @@ class VaspDrone(AbstractDrone):
             d["output"]["normalmode_eigenvecs"] = vrun.normalmode_eigenvecs.tolist()
         return d
 
-    def process_volumetric(self, dir_name, taskname="standard"):
+    def process_raw_data(self, dir_name, taskname="standard"):
         """
-        It is useful to store what volumetric data has been
-        calculated.
+        It is useful to store what raw data has been calculated
+        and exists for easier querying of the taskdoc.
 
         :param dir_name: directory to search
         :param taskname: taskname, e.g. "relax1"
         :return: dict of files present
         """
         d = {}
-        possible_files = ('CHGCAR', 'LOCPOT', 'AECCAR0', 'AECCAR1', 'AECCAR2', 'ELFCAR')
+        possible_files = ('CHGCAR', 'LOCPOT', 'AECCAR0', 'AECCAR1', 'AECCAR2',
+                          'ELFCAR', 'WAVECAR', 'PROCAR', 'OPTIC')
         for f in possible_files:
             files = self.filter_files(dir_name, file_pattern=f)
             if taskname in files:

--- a/atomate/vasp/tests/test_drones.py
+++ b/atomate/vasp/tests/test_drones.py
@@ -25,6 +25,7 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
         cls.relax2 = os.path.join(module_dir, "..", "test_files", "Si_structure_optimization_relax2",
                                  "outputs")
         cls.Al = os.path.join(module_dir, "..", "test_files", "Al")
+        cls.Si_static = os.path.join(module_dir, "..", "test_files", "Si_static", "outputs")
 
     def test_assimilate(self):
         drone = VaspDrone()
@@ -77,6 +78,22 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             self.assertEqual(d["bandgap"], 0.0)
             self.assertFalse(d["is_gap_direct"])
             self.assertTrue(d["is_metal"])
+
+    def test_volumetric(self):
+        drone = VaspDrone()
+        doc = drone.assimilate(self.Si_static)
+
+        self.assertDictEqual({
+            'chgcar': 'CHGCAR.gz',
+            'locpot': 'LOCPOT.gz',
+            'aeccar0': 'AECCAR0.gz',
+            'aeccar1': 'AECCAR1.gz',
+            'aeccar2': 'AECCAR2.gz'
+        }, doc['calcs_reversed'][0]['volumetric_data'])
+
+        doc = drone.assimilate(self.relax2)
+        self.assertDictEqual({'chgcar': 'CHGCAR.relax1.gz'},
+                             doc['calcs_reversed'][1]['volumetric_data'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/atomate/vasp/tests/test_drones.py
+++ b/atomate/vasp/tests/test_drones.py
@@ -88,12 +88,15 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             'locpot': 'LOCPOT.gz',
             'aeccar0': 'AECCAR0.gz',
             'aeccar1': 'AECCAR1.gz',
-            'aeccar2': 'AECCAR2.gz'
-        }, doc['calcs_reversed'][0]['volumetric_data'])
+            'aeccar2': 'AECCAR2.gz',
+            'procar': 'PROCAR.gz',
+            'wavecar': 'WAVECAR.gz'
+        }, doc['calcs_reversed'][0]['datafiles'])
 
         doc = drone.assimilate(self.relax2)
-        self.assertDictEqual({'chgcar': 'CHGCAR.relax1.gz'},
-                             doc['calcs_reversed'][1]['volumetric_data'])
+        self.assertDictEqual({'chgcar': 'CHGCAR.relax1.gz', 'procar': 'PROCAR.relax1.gz',
+                              'wavecar': 'WAVECAR.relax1.gz'},
+                             doc['calcs_reversed'][1]['datafiles'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/atomate/vasp/tests/test_drones.py
+++ b/atomate/vasp/tests/test_drones.py
@@ -79,7 +79,7 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             self.assertFalse(d["is_gap_direct"])
             self.assertTrue(d["is_metal"])
 
-    def test_volumetric(self):
+    def test_detect_datafiles(self):
         drone = VaspDrone()
         doc = drone.assimilate(self.Si_static)
 

--- a/atomate/vasp/tests/test_drones.py
+++ b/atomate/vasp/tests/test_drones.py
@@ -79,7 +79,7 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             self.assertFalse(d["is_gap_direct"])
             self.assertTrue(d["is_metal"])
 
-    def test_detect_datafiles(self):
+    def test_detect_output_file_paths(self):
         drone = VaspDrone()
         doc = drone.assimilate(self.Si_static)
 
@@ -91,12 +91,12 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             'aeccar2': 'AECCAR2.gz',
             'procar': 'PROCAR.gz',
             'wavecar': 'WAVECAR.gz'
-        }, doc['calcs_reversed'][0]['datafiles'])
+        }, doc['calcs_reversed'][0]['output_file_paths'])
 
         doc = drone.assimilate(self.relax2)
         self.assertDictEqual({'chgcar': 'CHGCAR.relax1.gz', 'procar': 'PROCAR.relax1.gz',
                               'wavecar': 'WAVECAR.relax1.gz'},
-                             doc['calcs_reversed'][1]['datafiles'])
+                             doc['calcs_reversed'][1]['output_file_paths'])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This simply adds information to `calcs_reversed` on what volumetric data is present for easier querying of the tasks collection.

This doesn't address *how* we may one day want to store the volumetric data itself (#139), which is a much larger question.

@tschaume is using the Atomate drone on large set of tasks soon, so this (or something like it) would be useful to have for that, to save having to re-run it later.