### PR TITLE
Add anharmonic support to Gibbs free energy workflow

### DIFF
--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -181,6 +181,7 @@ class BoltztrapToDb(FiretaskBase):
         v, o = get_vasprun_outcar(bandstructure_dir, parse_eigen=False, parse_dos=False)
         structure = v.final_structure
         d["structure"] = structure.as_dict()
+        d["formula_pretty"] = structure.composition.reduced_formula
         d.update(get_meta_from_structure(structure))
 
         # add the spacegroup
@@ -373,6 +374,7 @@ class RamanTensorToDb(FiretaskBase):
         nm_frequencies = np.sqrt(np.abs(nm_eigenvals)) * 82.995  # cm^-1
 
         d = {"structure": structure.as_dict(),
+             "formula_pretty": structure.composition.reduced_formula,
              "normalmodes": {"eigenvals": fw_spec["normalmodes"]["eigenvals"],
                              "eigenvecs": fw_spec["normalmodes"]["eigenvecs"]
                              },
@@ -474,6 +476,7 @@ class GibbsAnalysisToDb(FiretaskBase):
                                      {"calcs_reversed": 1})
         structure = Structure.from_dict(d["calcs_reversed"][-1]["output"]['structure'])
         gibbs_dict["structure"] = structure.as_dict()
+        gibbs_dict["formula_pretty"] = structure.composition.reduced_formula
 
         # get the data(energy, volume, force constant) from the deformation runs
         docs = mmdb.collection.find({"task_label": {"$regex": "{} gibbs*".format(tag)},
@@ -584,6 +587,7 @@ class FitEOSToDb(FiretaskBase):
         all_task_ids.append(d["task_id"])
         structure = Structure.from_dict(d["calcs_reversed"][-1]["output"]['structure'])
         summary_dict["structure"] = structure.as_dict()
+        summary_dict["formula_pretty"] = structure.composition.reduced_formula
 
         # get the data(energy, volume, force constant) from the deformation runs
         docs = mmdb.collection.find({"task_label": {"$regex": "{} bulk_modulus*".format(tag)},
@@ -666,6 +670,7 @@ class ThermalExpansionCoeffToDb(FiretaskBase):
         d = mmdb.collection.find_one({"task_label": "{} structure optimization".format(tag)})
         structure = Structure.from_dict(d["calcs_reversed"][-1]["output"]['structure'])
         summary_dict["structure"] = structure.as_dict()
+        summary_dict["formula_pretty"] = structure.composition.reduced_formula
 
         # get the data(energy, volume, force constant) from the deformation runs
         docs = mmdb.collection.find({"task_label": {"$regex": "{} thermal_expansion*".format(tag)},

--- a/atomate/vasp/workflows/base/gibbs.py
+++ b/atomate/vasp/workflows/base/gibbs.py
@@ -26,7 +26,8 @@ logger = get_logger(__name__)
 def get_wf_gibbs_free_energy(structure, deformations, vasp_input_set=None, vasp_cmd="vasp",
                              db_file=None, user_kpoints_settings=None, t_step=10, t_min=0,
                              t_max=1000, mesh=(20, 20, 20), eos="vinet", qha_type="debye_model",
-                             pressure=0.0, poisson=0.25, metadata=None, tag=None):
+                             pressure=0.0, poisson=0.25, anharmonic_contribution=False,
+                             metadata=None, tag=None):
     """
     Returns quasi-harmonic gibbs free energy workflow.
     Note: phonopy package is required for the final analysis step if qha_type="phonopy"
@@ -49,6 +50,8 @@ def get_wf_gibbs_free_energy(structure, deformations, vasp_input_set=None, vasp_
             default is "debye_model"
         pressure (float): in GPa
         poisson (float): poisson ratio
+        anharmonic_contribution (bool): consider anharmonic contributions to
+            Gibbs energy from the Debye model. Defaults to False.
         metadata (dict): meta data
         tag (str): something unique to identify the tasks in this workflow. If None a random uuid
             will be assigned.
@@ -82,7 +85,8 @@ def get_wf_gibbs_free_energy(structure, deformations, vasp_input_set=None, vasp_
 
     fw_analysis = Firework(GibbsAnalysisToDb(tag=tag, db_file=db_file, t_step=t_step, t_min=t_min,
                                              t_max=t_max, mesh=mesh, eos=eos, qha_type=qha_type,
-                                             pressure=pressure, poisson=poisson, metadata=metadata),
+                                             pressure=pressure, poisson=poisson, metadata=metadata,
+                                             anharmonic_contribution=anharmonic_contribution,),
                            name="Gibbs Free Energy")
 
     wf_gibbs.append_wf(Workflow.from_Firework(fw_analysis), wf_gibbs.leaf_fw_ids)

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -321,7 +321,8 @@ def wf_gibbs_free_energy(structure, c=None):
     metadata = c.get("METADATA", None)
 
     # 21 deformed structures: from -10% to +10%
-    deformations = [(np.identity(3)*(1+x)).tolist() for x in np.linspace(-0.1, 0.1, 21)]
+    defos = [(np.identity(3)*(1+x)).tolist() for x in np.linspace(-0.1, 0.1, 21)]
+    deformations = c.get("DEFORMATIONS", defos)
     user_kpoints_settings = {"grid_density": 7000}
 
     tag = "gibbs group: >>{}<<".format(str(uuid4()))

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -317,6 +317,7 @@ def wf_gibbs_free_energy(structure, c=None):
     t_step = c.get("T_STEP", 100.0)
     pressure = c.get("PRESSURE", 0.0)
     poisson = c.get("POISSON", 0.25)
+    anharmonic_contribution = c.get("ANHARMONIC_CONTRIBUTION", False)
     metadata = c.get("METADATA", None)
 
     # 21 deformed structures: from -10% to +10%
@@ -360,6 +361,7 @@ def wf_gibbs_free_energy(structure, c=None):
                                         deformations=deformations, vasp_cmd=vasp_cmd, db_file=db_file,
                                         eos=eos, qha_type=qha_type, pressure=pressure, poisson=poisson,
                                         t_min=t_min, t_max=t_max, t_step=t_step, metadata=metadata,
+                                        anharmonic_contribution=anharmonic_contribution,
                                         tag=tag, vasp_input_set=vis_static)
 
     # chaining


### PR DESCRIPTION
The QuasiharmonicDebyeApprox was updated in pymatgen to support adding the anharmonic part of the vibrational free energy to the Debye model.

A new version of pymatgen has been released with these changes and this PR adds that functionality here.

This includes a small change allowing deformations to be customized in the preset workflow as well as whether to include the anharmonic contribution, but leaves all of the defaults unchanged.

**Note: depends on #145. Please merge that first!**