### PR TITLE
New optimization scheme

### DIFF
--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -83,11 +83,12 @@ class RunVaspCustodian(FiretaskBase):
         gamma_vasp_cmd: (str) - cmd for Gamma-optimized VASP compilation.
             Supports env_chk.
         wall_time (int): Total wall time in seconds. Activates WalltimeHandler if set.
+        half_kpts_first_relax (bool): Use half the k-points for the first relaxation
     """
     required_params = ["vasp_cmd"]
     optional_params = ["job_type", "handler_group", "max_force_threshold", "scratch_dir",
                        "gzip_output", "max_errors", "ediffg", "auto_npar", "gamma_vasp_cmd",
-                       "wall_time"]
+                       "wall_time","half_kpts_first_relax"]
 
     def run_task(self, fw_spec):
 
@@ -125,11 +126,12 @@ class RunVaspCustodian(FiretaskBase):
         elif job_type == "double_relaxation_run":
             jobs = VaspJob.double_relaxation_run(vasp_cmd, auto_npar=auto_npar,
                                                  ediffg=self.get("ediffg"),
-                                                 half_kpts_first_relax=False)
+                                                 half_kpts_first_relax=self.get("half_kpts_first_relax",True))
         elif job_type == "full_opt_run":
             jobs = VaspJob.full_opt_run(vasp_cmd, auto_npar=auto_npar,
                                         ediffg=self.get("ediffg"),
-                                        max_steps=9, half_kpts_first_relax=False)
+                                        max_steps=9,
+                                        half_kpts_first_relax=self.get("half_kpts_first_relax", True))
         elif job_type == "neb":
             # TODO: @shyuep @HanmeiTang This means that NEB can only be run (i) in reservation mode
             # and (ii) when the queueadapter parameter is overridden and (iii) the queue adapter

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -170,7 +170,7 @@ class RunVaspCustodian(FiretaskBase):
         # construct handlers
         handlers = handler_groups[self.get("handler_group", "default")]
 
-        if self.get("max_force_threshold") and self.get("ediffg",0.1) > 0:
+        if self.get("max_force_threshold"):
             handlers.append(MaxForceErrorHandler(max_force_threshold=self["max_force_threshold"]))
 
         if self.get("wall_time"):

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -125,11 +125,11 @@ class RunVaspCustodian(FiretaskBase):
             jobs = [VaspJob(vasp_cmd, auto_npar=auto_npar, gamma_vasp_cmd=gamma_vasp_cmd)]
         elif job_type == "double_relaxation_run":
             jobs = VaspJob.double_relaxation_run(vasp_cmd, auto_npar=auto_npar,
-                                                 ediffg=self.get("ediffg"),
+                                                 ediffg=self.get("ediffg",-0.05),
                                                  half_kpts_first_relax=self.get("half_kpts_first_relax",True))
         elif job_type == "full_opt_run":
             jobs = VaspJob.full_opt_run(vasp_cmd, auto_npar=auto_npar,
-                                        ediffg=self.get("ediffg"),
+                                        ediffg=self.get("ediffg",-0.05),
                                         max_steps=9,
                                         half_kpts_first_relax=self.get("half_kpts_first_relax", True))
         elif job_type == "neb":

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -170,7 +170,7 @@ class RunVaspCustodian(FiretaskBase):
         # construct handlers
         handlers = handler_groups[self.get("handler_group", "default")]
 
-        if self.get("max_force_threshold"):
+        if self.get("max_force_threshold") and self.get("ediffg",0.1) > 0:
             handlers.append(MaxForceErrorHandler(max_force_threshold=self["max_force_threshold"]))
 
         if self.get("wall_time"):

--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -30,7 +30,7 @@ from atomate.vasp.firetasks.neb_tasks import WriteNEBFromImages, WriteNEBFromEnd
 class OptimizeFW(Firework):
     def __init__(self, structure, name="structure optimization", vasp_input_set=None,
                  vasp_cmd="vasp", override_default_vasp_params=None, ediffg=-0.05, db_file=None,
-                 force_gamma=True, job_type="double_relaxation_run", max_force_threshold=0.25,
+                 force_gamma=True, job_type="double_relaxation_run", max_force_threshold=0,
                  auto_npar=">>auto_npar<<",half_kpts_first_relax=True, parents=None, **kwargs):
         """
         Optimize the given structure.

--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -29,9 +29,9 @@ from atomate.vasp.firetasks.neb_tasks import WriteNEBFromImages, WriteNEBFromEnd
 
 class OptimizeFW(Firework):
     def __init__(self, structure, name="structure optimization", vasp_input_set=None,
-                 vasp_cmd="vasp", override_default_vasp_params=None, ediffg=None, db_file=None,
+                 vasp_cmd="vasp", override_default_vasp_params=None, ediffg=-0.05, db_file=None,
                  force_gamma=True, job_type="double_relaxation_run", max_force_threshold=0.25,
-                 auto_npar=">>auto_npar<<", parents=None, **kwargs):
+                 auto_npar=">>auto_npar<<",half_kpts_first_relax=True, parents=None, **kwargs):
         """
         Optimize the given structure.
 
@@ -49,6 +49,7 @@ class OptimizeFW(Firework):
             job_type (str): custodian job type (default "double_relaxation_run")
             max_force_threshold (float): max force on a site allowed at end; otherwise, reject job
             auto_npar (bool or str): whether to set auto_npar. defaults to env_chk: ">>auto_npar<<"
+            half_kpts_first_relax (bool): whether to use half the kpoints for the first relaxation
             parents ([Firework]): Parents of this particular Firework.
             \*\*kwargs: Other kwargs that are passed to Firework.__init__.
         """
@@ -60,7 +61,7 @@ class OptimizeFW(Firework):
         t.append(WriteVaspFromIOSet(structure=structure, vasp_input_set=vasp_input_set))
         t.append(RunVaspCustodian(vasp_cmd=vasp_cmd, job_type=job_type,
                                   max_force_threshold=max_force_threshold, ediffg=ediffg,
-                                  auto_npar=auto_npar))
+                                  auto_npar=auto_npar, half_kpts_first_relax=half_kpts_first_relax))
         t.append(PassCalcLocs(name=name))
         t.append(VaspToDb(db_file=db_file, additional_fields={"task_label": name}))
         super(OptimizeFW, self).__init__(t, parents=parents, name="{}-{}".


### PR DESCRIPTION
Updating the optimization per #19 

Switched ediffg to default to -0.05
changed default to not include MaxForceErrorHandler 
add in half_kpts_first_relax and set to default to true

Currently, we use double relaxations. Would it make sense to switch to full opt since that enables the 2% vol change check @shyuep recommends? Does this primarily mitigate issues with Pulay stresses?

In reference to @montoyjh's suggestion of looking into the FFT  grid size, I ran some test calculations of GGA+U and SCAN optimizations for Si, Fe, Al2O3, Fe2O3, and GaN after rattling all atoms + one significant perturbation. In all cases setting ENAUG to 4*ENCUT was as at minimum 7% faster average over 4 tries, and in some cases as much as 54% faster. The resulting structures and energies all matched with the expected values from MP, or in the case of SCAN were self-consistent. The benefit seems to scale with the complexity of the calculation, more atoms = bigger speedup. 