### PR TITLE
Update Bandstructure parsing in Drone

### DIFF
--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -276,7 +276,7 @@ class VaspDrone(AbstractDrone):
         """
         vasprun_file = os.path.join(dir_name, filename)
 
-        vrun = Vasprun(vasprun_file, parse_eigen=True, parse_projected_eigen=True)
+        vrun = Vasprun(vasprun_file, parse_projected_eigen=True)
 
         d = vrun.as_dict()
 

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -74,7 +74,7 @@ class VaspDrone(AbstractDrone):
                      'warnings'}
     }
 
-    def __init__(self, runs=None, parse_dos=False, compress_dos=False, bandstructure_mode="Auto",
+    def __init__(self, runs=None, parse_dos="auto", compress_dos=False, bandstructure_mode="auto",
                  compress_bs=False, additional_fields=None, use_full_uri=True):
         self.parse_dos = parse_dos
         self.compress_dos = compress_dos

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -234,7 +234,11 @@ class VaspDrone(AbstractDrone):
                                     "is_gap_direct": calc["output"]["is_gap_direct"],
                                     "is_metal": calc["output"]["is_metal"]})
             except Exception:
-                pass
+                if self.bandstructure_mode is True:
+                    import traceback
+                    logger.error(traceback.format_exc())
+                    logger.error("Error in " + os.path.abspath(dir_name) + ".\n" + traceback.format_exc())
+                    raise
 
             sg = SpacegroupAnalyzer(Structure.from_dict(d_calc_final["output"]["structure"]), 0.1)
             if not sg.get_symmetry_dataset():

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -315,7 +315,7 @@ class VaspDrone(AbstractDrone):
             if vrun.incar.get("ICHARG", 0) > 10 and vrun.kpoints.num_kpts > 0:
                 bs_vrun = BSVasprun(vasprun_file, parse_projected_eigen=True)
                 bs = bs_vrun.get_band_structure(line_mode=True)
-            # else if uniform nscf
+            # else if nscf
             elif vrun.incar.get("ICHARG", 0) > 10 :
                 bs_vrun = BSVasprun(vasprun_file, parse_projected_eigen=True)
                 bs = bs_vrun.get_band_structure()
@@ -329,8 +329,9 @@ class VaspDrone(AbstractDrone):
         # legacy line/True behavior for bandstructure_mode
         elif self.bandstructure_mode:
             bs_vrun = BSVasprun(vasprun_file,parse_projected_eigen=True)
-            bs = bs_vrun.get_band_structure()
+            bs = bs_vrun.get_band_structure(line_mode=(str(self.bandstructure_mode).lower() == "line"))
             d["bandstructure"] = bs.as_dict()
+        # parse bandstructure for vbm/cbm/bandgap but don't save
         else:
             bs = vrun.get_band_structure()
 

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -345,6 +345,11 @@ class VaspDrone(AbstractDrone):
             d["output"]["is_metal"] = bs.is_metal()
 
         except Exception:
+            if self.bandstructure_mode is True:
+                import traceback
+                logger.error(traceback.format_exc())
+                logger.error("Error in " + os.path.abspath(dir_name) + ".\n" + traceback.format_exc())
+                raise
             logger.warning("Error in parsing bandstructure")
             if vrun.incar["IBRION"] == 1:
                 logger.warning("Vasp doesn't properly output efermi for IBRION == 1")

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -317,11 +317,10 @@ class VaspDrone(AbstractDrone):
         # Parse electronic information if possible.
         # For certain optimizers this is broken and we don't get an efermi resulting in the bandstructure
         try:
+            bs_gap = bs.get_band_gap()
             d["bandstructure"] = bs.as_dict()
-
             d["output"]["vbm"] = bs.get_vbm()["energy"]
             d["output"]["cbm"] = bs.get_cbm()["energy"]
-            bs_gap = bs.get_band_gap()
             d["output"]["bandgap"] = bs_gap["energy"]
             d["output"]["is_gap_direct"] = bs_gap["direct"]
             d["output"]["is_metal"] = bs.is_metal()

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -330,7 +330,7 @@ class VaspDrone(AbstractDrone):
 
         except Exception:
             logger.warning("Error in parsing bandstructure")
-            if v.incar["IBRION"] == 1:
+            if vrun.incar["IBRION"] == 1:
                 logger.warning("Vasp doesn't properly output efermi for IBRION == 1")
 
         d["task"] = {"type": taskname, "name": taskname}

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -275,10 +275,8 @@ class VaspDrone(AbstractDrone):
         Process a vasprun.xml file.
         """
         vasprun_file = os.path.join(dir_name, filename)
-        if self.bandstructure_mode:
-            vrun = Vasprun(vasprun_file, parse_eigen=True, parse_projected_eigen=True)
-        else:
-            vrun = Vasprun(vasprun_file)
+
+        vrun = Vasprun(vasprun_file, parse_eigen=True, parse_projected_eigen=True)
 
         d = vrun.as_dict()
 

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -76,6 +76,27 @@ class VaspDrone(AbstractDrone):
 
     def __init__(self, runs=None, parse_dos="auto", compress_dos=False, bandstructure_mode="auto",
                  compress_bs=False, additional_fields=None, use_full_uri=True):
+        """
+        Initialize a Vasp drone to parse vasp outputs
+        Args:
+            runs (list): Naming scheme for multiple calcuations in on folder e.g. ["relax1","relax2"].
+             Can be subfolder or extension
+            parse_dos (str or bool): Whether to parse the DOS. Can be "auto", True or False.
+            "auto" will only parse DOS if NSW = 0, so there are no ionic steps
+            compress_dos (bool): Compress DOS using zlib or not
+            bandstructure_mode (str or bool): How to parse the bandstructure or not. Can be "auto","line", True or False.
+             "auto" will parse the bandstructure with projections for NSCF calcs and decide automatically
+              if it's line mode or uniform. Saves the bandstructure in the output doc.
+             "line" will parse the bandstructure as a line mode calculation with projections.
+              Saves the bandstructure in the output doc.
+             True will parse the bandstructure with projections as a uniform calculation.
+              Saves the bandstructure in the output doc.
+             False will parse the bandstructure without projections to calculate vbm, cbm, band_gap, is_metal and efermi
+              Dose not saves the bandstructure in the output doc.
+            compress_bs (bool): Compress the bandstructure using zlib or not
+            additional_fields (dict): dictionary of additional fields to add to output document
+            use_full_uri (bool): converts the directory path to the full URI path
+        """
         self.parse_dos = parse_dos
         self.compress_dos = compress_dos
         self.additional_fields = additional_fields or {}

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -75,7 +75,7 @@ class VaspDrone(AbstractDrone):
                      'warnings'}
     }
 
-    def __init__(self, runs=None, parse_dos=False, compress_dos=False, bandstructure_mode=False,
+    def __init__(self, runs=None, parse_dos=False, compress_dos=False, bandstructure_mode="Auto",
                  compress_bs=False, additional_fields=None, use_full_uri=True):
         self.parse_dos = parse_dos
         self.compress_dos = compress_dos

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -28,7 +28,6 @@ from pymatgen.io.vasp import BSVasprun, Vasprun, Outcar
 from pymatgen.io.vasp.inputs import Poscar, Potcar, Incar, Kpoints
 from pymatgen.apps.borg.hive import AbstractDrone
 
-
 from matgendb.creator import get_uri
 
 from atomate.utils.utils import get_logger
@@ -252,7 +251,7 @@ class VaspDrone(AbstractDrone):
                 for k in ['epsilon_static', 'epsilon_static_wolfe', 'epsilon_ionic']:
                     d["output"][k] = d_calc_final["output"][k]
                 if SymmOp.inversion() not in sg.get_symmetry_operations():
-                    for k in ["piezo_ionic_tensor","piezo_tensor"]:
+                    for k in ["piezo_ionic_tensor", "piezo_tensor"]:
                         d["output"][k] = d_calc_final["output"]["outcar"][k]
 
             d["state"] = "successful" if d_calc["has_vasp_completed"] else "unsuccessful"
@@ -303,7 +302,7 @@ class VaspDrone(AbstractDrone):
         for k, v in {"energy": "final_energy", "energy_per_atom": "final_energy_per_atom"}.items():
             d["output"][k] = d["output"].pop(v)
 
-        if self.parse_dos and self.parse_dos != 'final':
+        if self.parse_dos or (str(self.parse_dos).lower() == "auto" and vrun.incar.get("NSW", 1) == 0):
             try:
                 d["dos"] = vrun.complete_dos.as_dict()
             except:
@@ -316,7 +315,7 @@ class VaspDrone(AbstractDrone):
                 bs_vrun = BSVasprun(vasprun_file, parse_projected_eigen=True)
                 bs = bs_vrun.get_band_structure(line_mode=True)
             # else if nscf
-            elif vrun.incar.get("ICHARG", 0) > 10 :
+            elif vrun.incar.get("ICHARG", 0) > 10:
                 bs_vrun = BSVasprun(vasprun_file, parse_projected_eigen=True)
                 bs = bs_vrun.get_band_structure()
             # else just regular calculation
@@ -328,7 +327,7 @@ class VaspDrone(AbstractDrone):
                 d["bandstructure"] = bs.as_dict()
         # legacy line/True behavior for bandstructure_mode
         elif self.bandstructure_mode:
-            bs_vrun = BSVasprun(vasprun_file,parse_projected_eigen=True)
+            bs_vrun = BSVasprun(vasprun_file, parse_projected_eigen=True)
             bs = bs_vrun.get_band_structure(line_mode=(str(self.bandstructure_mode).lower() == "line"))
             d["bandstructure"] = bs.as_dict()
         # parse bandstructure for vbm/cbm/bandgap but don't save

--- a/atomate/vasp/tests/test_drones.py
+++ b/atomate/vasp/tests/test_drones.py
@@ -68,6 +68,33 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
 
     def test_bandstructure(self):
         drone = VaspDrone()
+
+        doc = drone.assimilate(self.relax2)
+        self.assertEqual(doc["composition_reduced"], {'Si': 1.0})
+        self.assertEqual(doc["formula_pretty"], 'Si')
+        self.assertEqual(doc["formula_anonymous"], 'A')
+        for d in [doc["calcs_reversed"][0]["output"], doc["output"]]:
+            self.assertAlmostEqual(d["vbm"],5.6147)
+            self.assertAlmostEqual(d["cbm"],6.2652)
+            self.assertAlmostEqual(d["bandgap"], 0.6505)
+            self.assertFalse(d["is_gap_direct"])
+            self.assertFalse(d["is_metal"])
+            self.assertNotIn("bandstructure",doc["calcs_reversed"][0])
+
+
+        doc = drone.assimilate(self.Si_static)
+        self.assertEqual(doc["composition_reduced"], {'Si': 1.0})
+        self.assertEqual(doc["formula_pretty"], 'Si')
+        self.assertEqual(doc["formula_anonymous"], 'A')
+        for d in [doc["calcs_reversed"][0]["output"], doc["output"]]:
+            self.assertAlmostEqual(d["vbm"],5.6138)
+            self.assertAlmostEqual(d["cbm"],6.2644)
+            self.assertAlmostEqual(d["bandgap"],  0.6506)
+            self.assertFalse(d["is_gap_direct"])
+            self.assertFalse(d["is_metal"])
+            self.assertIn("bandstructure", doc["calcs_reversed"][0])
+
+
         doc = drone.assimilate(self.Al)
         self.assertEqual(doc["composition_reduced"], {'Al': 1.0})
         self.assertEqual(doc["formula_pretty"], 'Al')
@@ -78,6 +105,7 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             self.assertEqual(d["bandgap"], 0.0)
             self.assertFalse(d["is_gap_direct"])
             self.assertTrue(d["is_metal"])
+            self.assertEqual(doc["calcs_reversed"][0]["bandstructure"]["@class"],"BandStructureSymmLine")
 
     def test_detect_output_file_paths(self):
         drone = VaspDrone()


### PR DESCRIPTION
## Summary
Fixed a bug in the drone for parsing runs with IBRION==1 where VASP fails to output efermi
Added in logic to determine if a run is uniform or line for nscf calculations and create the right type of Bandstructure class
