### PR TITLE
Powerup to Preserve Fworker  and include DriftErrorHandler

### DIFF
--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -22,7 +22,7 @@ from custodian import Custodian
 from custodian.vasp.handlers import VaspErrorHandler, AliasingErrorHandler, \
     MeshSymmetryErrorHandler, UnconvergedErrorHandler, MaxForceErrorHandler, PotimErrorHandler, \
     FrozenJobErrorHandler, NonConvergingErrorHandler, PositiveEnergyErrorHandler, \
-    WalltimeHandler, StdErrHandler
+    WalltimeHandler, StdErrHandler, DriftErrorHandler
 from custodian.vasp.jobs import VaspJob, VaspNEBJob
 from custodian.vasp.validators import VasprunXMLValidator, VaspFilesValidator
 
@@ -172,6 +172,8 @@ class RunVaspCustodian(FiretaskBase):
         # construct handlers
         handlers = handler_groups[self.get("handler_group", "default")]
 
+        if self.get("ediffg"):
+            handlers.append(DriftErrorHandler())
         if self.get("max_force_threshold"):
             handlers.append(MaxForceErrorHandler(max_force_threshold=self["max_force_threshold"]))
 

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -97,11 +97,12 @@ class RunVaspCustodian(FiretaskBase):
         handler_groups = {
             "default": [VaspErrorHandler(), MeshSymmetryErrorHandler(), UnconvergedErrorHandler(),
                         NonConvergingErrorHandler(),PotimErrorHandler(),
-                        PositiveEnergyErrorHandler(), FrozenJobErrorHandler(), StdErrHandler()],
+                        PositiveEnergyErrorHandler(), FrozenJobErrorHandler(), StdErrHandler(),
+                        DriftErrorHandler()],
             "strict": [VaspErrorHandler(), MeshSymmetryErrorHandler(), UnconvergedErrorHandler(),
                        NonConvergingErrorHandler(),PotimErrorHandler(),
                        PositiveEnergyErrorHandler(), FrozenJobErrorHandler(),
-                       StdErrHandler(), AliasingErrorHandler()],
+                       StdErrHandler(), AliasingErrorHandler(), DriftErrorHandler()],
             "md": [VaspErrorHandler(), NonConvergingErrorHandler()],
             "no_handler": []
             }
@@ -172,8 +173,6 @@ class RunVaspCustodian(FiretaskBase):
         # construct handlers
         handlers = handler_groups[self.get("handler_group", "default")]
 
-        if self.get("ediffg"):
-            handlers.append(DriftErrorHandler())
         if self.get("max_force_threshold"):
             handlers.append(MaxForceErrorHandler(max_force_threshold=self["max_force_threshold"]))
 

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -316,8 +316,10 @@ def set_fworker(original_wf, fworker_name, fw_name_constraint=None, task_name_co
 
 def preserve_fworker(original_wf, fw_name_constraint=None):
     """
-    set _preserve_fworker spec of Fireworker(s) of a Workflow. Can be used to ensure 
-    the workflow runs on the same machine
+    set _preserve_fworker spec of Fireworker(s) of a Workflow. Can be used to pin a workflow to 
+    the first fworker it is run with. Very useful when running on multiple machines that can't 
+    share files. fw_name_constraint can be used to only preserve fworker after a certain point 
+    where file passing becomes important
 
     Args:
         original_wf (Workflow):

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -314,6 +314,21 @@ def set_fworker(original_wf, fworker_name, fw_name_constraint=None, task_name_co
         original_wf.fws[idx_fw].spec["_fworker"] = fworker_name
     return original_wf
 
+def preserve_fworker(original_wf, fw_name_constraint=None):
+    """
+    set _preserve_fworker spec of Fireworker(s) of a Workflow. Can be used to ensure 
+    the workflow runs on the same machine
+
+    Args:
+        original_wf (Workflow):
+        fw_name_constraint (str): name of the Fireworks to be tagged (all if None is passed)
+
+    Returns:
+        Workflow: modified workflow with specified Fireworkers tagged
+    """
+    for idx_fw, idx_t in get_fws_and_tasks(original_wf, fw_name_constraint=fw_name_constraint):
+        original_wf.fws[idx_fw].spec["_preserve_fworker"] = True
+    return original_wf
 
 def add_wf_metadata(original_wf, structure):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ FireWorks==1.5.3
 pymatgen==2017.9.23
 pymatgen-db==0.7.0
 pymatgen_diffusion==0.3.0
-custodian==1.1.0
+custodian==1.1.1
 monty==1.0.1
 paramiko==2.1.2
 tqdm==4.11.2


### PR DESCRIPTION
Changes

1. Little powerup that sets _preserve_fworker
Useful for those of us who spend a few hours writing code to do just this and then realize the 
functionality was already there......
2. Included DriftErrorHandler when ediffg is set. 


