### PR TITLE
Added GetInterpolatedPOSCAR + test and modified CopyVaspOutputs. (pull request 2/5)

### DIFF
--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -141,17 +141,24 @@ class CreateFolder(FiretaskBase):
 
     Required params:
         folder_name (str): folder name.
-        change_to (bool): change to new folder.
 
+    Optional params:
+        change_to (bool): change to new folder. Defaults to False.
+        local (bool): whether folder name is relative or absolute. Defaults to True.
     """
-    required_params = ["folder_name","change_to"]
+    required_params = ["folder_name"]
+    optional_params = ["change_to", "local"]
 
     def run_task(self, fw_spec):
-        folder = "/"+self.get("folder_name", "test")
-        if not os.path.exists(os.getcwd() + folder):
-            os.makedirs(os.getcwd() + folder)
+
+        if self.get("local", True):
+            new_dir = os.path.join(os.getcwd(), self["folder_name"])
+        else:
+            new_dir = os.path.join(self["folder_name"])
+        if not os.path.exists(new_dir):
+            os.makedirs(new_dir)
         if self.get("change_to", False):
-            os.chdir(os.getcwd() + folder)
+            os.chdir(new_dir)
 
 
 @explicit_serialize

--- a/atomate/vasp/firetasks/glue_tasks.py
+++ b/atomate/vasp/firetasks/glue_tasks.py
@@ -24,7 +24,7 @@ from pymatgen.core.structure import Structure
 from fireworks import explicit_serialize, FiretaskBase, FWAction
 
 from atomate.utils.utils import env_chk, get_logger
-from atomate.common.firetasks.glue_tasks import get_calc_loc, PassResult, CopyFiles, GrabFilesFromCalcLoc
+from atomate.common.firetasks.glue_tasks import get_calc_loc, PassResult, CopyFiles, CopyFilesFromCalcLoc
 
 logger = get_logger(__name__)
 
@@ -230,9 +230,9 @@ class GetInterpolatedPOSCAR(FiretaskBase):
             print (os.getcwd()+interpolate_folder)
 
         # use method of GrabFilesFromCalcLoc to grab files from previous locations.
-        GrabFilesFromCalcLoc(calc_dir=None, calc_loc=self.get("start","default"), filenames="CONTCAR",
+        CopyFilesFromCalcLoc(calc_dir=None, calc_loc=self.get("start","default"), filenames=["CONTCAR"],
                              name_prepend="interpolate/", name_append="_0").run_task(fw_spec=fw_spec)
-        GrabFilesFromCalcLoc(calc_dir=None, calc_loc=self.get("end","default"), filenames="CONTCAR",
+        CopyFilesFromCalcLoc(calc_dir=None, calc_loc=self.get("end","default"), filenames=["CONTCAR"],
                              name_prepend="interpolate/", name_append="_1").run_task(fw_spec=fw_spec)
 
         # assuming first calc_dir is polar structure for ferroelectric search

--- a/atomate/vasp/firetasks/glue_tasks.py
+++ b/atomate/vasp/firetasks/glue_tasks.py
@@ -241,9 +241,9 @@ class GetInterpolatedPOSCAR(FiretaskBase):
 
         # use method of GrabFilesFromCalcLoc to grab files from previous locations.
         CopyFilesFromCalcLoc(calc_dir=None, calc_loc=self.get("start","default"), filenames=["CONTCAR"],
-                             name_prepend="interpolate/", name_append="_0").run_task(fw_spec=fw_spec)
+                             name_prepend=interpolate_folder+"/", name_append="_0").run_task(fw_spec=fw_spec)
         CopyFilesFromCalcLoc(calc_dir=None, calc_loc=self.get("end","default"), filenames=["CONTCAR"],
-                             name_prepend="interpolate/", name_append="_1").run_task(fw_spec=fw_spec)
+                             name_prepend=interpolate_folder+"/", name_append="_1").run_task(fw_spec=fw_spec)
 
         # assuming first calc_dir is polar structure for ferroelectric search
 

--- a/atomate/vasp/firetasks/tests/test_get_interpolated_poscar.py
+++ b/atomate/vasp/firetasks/tests/test_get_interpolated_poscar.py
@@ -1,0 +1,93 @@
+# coding: utf-8
+
+from __future__ import division, print_function, unicode_literals, absolute_import
+
+import os
+import unittest
+
+from pymatgen.core.structure import Structure
+
+from fireworks import LaunchPad
+from fireworks.core.firework import Firework, Workflow
+from fireworks.core.rocket_launcher import rapidfire
+
+from atomate.common.firetasks.glue_tasks import PassCalcLocs, get_calc_loc
+from atomate.vasp.firetasks.glue_tasks import CopyVaspOutputs, GetInterpolatedPOSCAR
+from atomate.utils.testing import AtomateTest
+
+__author__ = 'Tess Smidt'
+__email__ = 'blondegeek@gmail.com'
+
+module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+
+DEBUG_MODE = False
+
+class TestGetInterpolatedPOSCAR(AtomateTest):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.static_outdir = os.path.join(module_dir, "..", "..", "test_files",
+                                         "Si_static", "outputs")
+        cls.opt_outdir = os.path.join(module_dir, "..", "..", "test_files",
+                                      "Si_structure_optimization", "outputs")
+
+    def test_getinterpolatedposcar(self):
+        nimages = 5
+        this_image = 1
+        autosort_tol = 0.5
+
+        fw1 = Firework([CopyVaspOutputs(calc_dir=self.static_outdir,
+                                        contcar_to_poscar=False,
+                                        additional_files=["CONTCAR"]),
+                        PassCalcLocs(name="fw1")], name="fw1")
+
+        fw2 = Firework([CopyVaspOutputs(calc_dir=self.opt_outdir,
+                                        contcar_to_poscar=False,
+                                        additional_files=["CONTCAR"]),
+                        PassCalcLocs(name="fw2")], name="fw2")
+
+        fw3 = Firework([GetInterpolatedPOSCAR(start="fw1",
+                                              end="fw2",
+                                              this_image=this_image,
+                                              nimages=nimages,
+                                              autosort_tol=autosort_tol),
+                        PassCalcLocs(name="fw3")],
+                       name="fw3", parents=[fw1, fw2])
+        fw4 = Firework([PassCalcLocs(name="fw4")], name="fw4", parents=fw3)
+
+        wf = Workflow([fw1, fw2, fw3, fw4])
+        self.lp.add_wf(wf)
+        rapidfire(self.lp)
+
+        fw4 = self.lp.get_fw_by_id(self.lp.get_fw_ids({"name": "fw4"})[0])
+
+        calc_locs = fw4.spec["calc_locs"]
+        self.assertTrue(os.path.exists(get_calc_loc("fw3", calc_locs)["path"] +
+                                       "/POSCAR"))
+        self.assertTrue(os.path.exists(get_calc_loc("fw3", calc_locs)["path"] +
+                                       "/interpolate/CONTCAR_0"))
+        self.assertTrue(os.path.exists(get_calc_loc("fw3", calc_locs)["path"] +
+                                       "/interpolate/CONTCAR_1"))
+
+        struct_start = Structure.from_file(get_calc_loc("fw3", calc_locs)["path"] +
+                                          "/interpolate/CONTCAR_0")
+        struct_end = Structure.from_file(get_calc_loc("fw3", calc_locs)["path"] +
+                                         "/interpolate/CONTCAR_1")
+        struct_inter = Structure.from_file(get_calc_loc("fw3", calc_locs)["path"] +
+                                           "/POSCAR")
+
+        structs = struct_start.interpolate(struct_end,
+                                           nimages,
+                                           interpolate_lattices=True,
+                                           autosort_tol=autosort_tol)
+
+        # Check x of 1st site.
+        self.assertAlmostEqual(structs[this_image][1].coords[0],
+                               struct_inter[1].coords[0])
+        # Check c lattice parameter
+        self.assertAlmostEqual(structs[this_image].lattice.abc[0],
+                               struct_inter.lattice.abc[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
GetInterpolatedPOSCAR get's the CONTCAR from a two previously run FireWorks and writes a specified interpolated structure as POSCAR.

The modification made to CopyVaspOutputs prevents moving CONTCAR->POSCAR if CONTCAR is included in additional_files and "contcar_to_poscar"=False.