### PR TITLE
optional parameters in CopyFilesFromCalcLoc

### DIFF
--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -89,7 +89,7 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         name_append (str): string to append to destination filenames.
         keep_filenames (bool): if True, all copied filenames are kept the same.
             The difference w/ not setting name_prepend and name_append is that
-            "foo/bar" can be in filenames copy from subfolder "foo" in calc_dir
+            "foo/bar" can be in filenames copied from subfolder foo in calc_dir
     """
 
     required_params = ["calc_loc", "filenames"]

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -87,13 +87,10 @@ class CopyFilesFromCalcLoc(FiretaskBase):
     Optional params:
         name_prepend (str): string to prepend filenames, e.g. can be a directory.
         name_append (str): string to append to destination filenames.
-        keep_filenames (bool): if True, all copied filenames are kept the same.
-            The difference w/ not setting name_prepend and name_append is that
-            "foo/bar" can be in filenames copied from subfolder foo in calc_dir
     """
 
     required_params = ["calc_loc", "filenames"]
-    optional_params = ["name_prepend", "name_append", "keep_filenames"]
+    optional_params = ["name_prepend", "name_append"]
 
     def run_task(self,fw_spec=None):
         calc_loc = get_calc_loc(self['calc_loc'], fw_spec["calc_locs"])

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -86,7 +86,8 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         filenames (list(str)): filenames to copy. Special behavior for:
             None: if filenames not set, all files in calc_loc will be copied
             '$ALL_NO_SUBDIRS' in filenames: similar to filenames is None
-            '$ALL' in filenames: all files and subfolders copied
+            '$ALL' in filenames: all files and subfolders copied, name_prepend
+                and name_append cannot be set in this case
         name_prepend (str): string to prepend filenames, e.g. can be a directory.
         name_append (str): string to append to destination filenames.
     """
@@ -109,6 +110,8 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         if '$ALL_NO_SUBDIRS' in filenames:
             files_to_copy = fileclient.listdir(calc_dir)
         elif '$ALL' in filenames:
+            if self.get('name_prepend', None) or self.get('name_append', None):
+                raise ValueError('name_prepend or name_append options not compatible with "$ALL" option')
             fileclient.copytree(calc_dir, os.getcwd())
             return
         else:

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -86,10 +86,11 @@ class CopyFilesFromCalcLoc(FiretaskBase):
     
     Optional params:
         name_prepend (str): string to prepend filenames, e.g. can be a directory.
-        name_append (str): string to append to filenames.
+        name_append (str): string to append to destination filenames.
     """
 
-    required_params = ["calc_loc", "filenames", "name_prepend","name_append"]
+    required_params = ["calc_loc", "filenames"]
+    optional_params = ["name_prepend", "name_append"]
 
     def run_task(self,fw_spec=None):
         calc_loc = get_calc_loc(self['calc_loc'], fw_spec["calc_locs"])

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -114,6 +114,8 @@ class CopyFilesFromCalcLoc(FiretaskBase):
                 raise ValueError('name_prepend or name_append options not compatible with "$ALL" option')
             fileclient.copytree(calc_dir, os.getcwd())
             return
+        else:
+            files_to_copy = filenames
 
         for f in files_to_copy:
             prev_path_full = os.path.join(calc_dir, f)

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -77,14 +77,16 @@ def get_calc_loc(target_name, calc_locs):
 class CopyFilesFromCalcLoc(FiretaskBase):
     """
     Based on CopyVaspOutputs but for general file copying. Note that "calc_locs"
-    must be set in the fw_spec.
+    must be set in the fw_spec. Files are copied to the current folder.
 
     Required params:
         calc_loc: name of target fw to get location for within the calc_locs.
     
     Optional params:
-        filenames (list(str)): filenames to copy. If not set, all files will be
-            copied.
+        filenames (list(str)): filenames to copy. Special behavior for:
+            None: if filenames not set, all files in calc_loc will be copied
+            '$ALL_NO_SUBDIRS' in filenames: similar to filenames is None
+            '$ALL' in filenames: all files and subfolders copied
         name_prepend (str): string to prepend filenames, e.g. can be a directory.
         name_append (str): string to append to destination filenames.
     """

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -81,16 +81,16 @@ class CopyFilesFromCalcLoc(FiretaskBase):
 
     Required params:
         calc_loc: name of target fw to get location for within the calc_locs.
-        filenames (list(str)): filenames to copy. If not set, all files will be
-            copied.
     
     Optional params:
+        filenames (list(str)): filenames to copy. If not set, all files will be
+            copied.
         name_prepend (str): string to prepend filenames, e.g. can be a directory.
         name_append (str): string to append to destination filenames.
     """
 
-    required_params = ["calc_loc", "filenames"]
-    optional_params = ["name_prepend", "name_append"]
+    required_params = ["calc_loc"]
+    optional_params = ["filenames", "name_prepend", "name_append"]
 
     def run_task(self,fw_spec=None):
         calc_loc = get_calc_loc(self['calc_loc'], fw_spec["calc_locs"])

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -99,22 +99,24 @@ class CopyFilesFromCalcLoc(FiretaskBase):
 
         fileclient = FileClient(filesystem=filesystem)
         calc_dir = fileclient.abspath(calc_dir)
-
-        if self.get('filenames'):
+        filenames = self.get('filenames', None)
+        if filenames:
             if isinstance(self["filenames"], six.string_types):
                 raise ValueError("filenames must be a list!")
-            files_to_copy = self['filenames']
-        else:
+
+        if '$ALL_NO_SUBDIRS' in filenames:
             files_to_copy = fileclient.listdir(calc_dir)
+        elif '$ALL' in filenames:
+            fileclient.copytree(calc_dir, os.getcwd())
+            return
+        else:
+            files_to_copy = filenames
 
         for f in files_to_copy:
             prev_path_full = os.path.join(calc_dir, f)
             dest_fname = self.get('name_prepend', "") + f + self.get(
                 'name_append', "")
-            if self.get('keep_filenames', False):
-                dest_path = os.path.join(os.getcwd(), ".")
-            else:
-                dest_path = os.path.join(os.getcwd(), dest_fname)
+            dest_path = os.path.join(os.getcwd(), dest_fname)
 
             fileclient.copy(prev_path_full, dest_path)
 

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -87,10 +87,13 @@ class CopyFilesFromCalcLoc(FiretaskBase):
     Optional params:
         name_prepend (str): string to prepend filenames, e.g. can be a directory.
         name_append (str): string to append to destination filenames.
+        keep_filenames (bool): if True, all copied filenames are kept the same.
+            The difference w/ not setting name_prepend and name_append is that
+            "foo/bar" can be in filenames copy from subfolder "foo" in calc_dir
     """
 
     required_params = ["calc_loc", "filenames"]
-    optional_params = ["name_prepend", "name_append"]
+    optional_params = ["name_prepend", "name_append", "keep_filenames"]
 
     def run_task(self,fw_spec=None):
         calc_loc = get_calc_loc(self['calc_loc'], fw_spec["calc_locs"])
@@ -111,7 +114,10 @@ class CopyFilesFromCalcLoc(FiretaskBase):
             prev_path_full = os.path.join(calc_dir, f)
             dest_fname = self.get('name_prepend', "") + f + self.get(
                 'name_append', "")
-            dest_path = os.path.join(os.getcwd(), dest_fname)
+            if self.get('keep_filenames', False):
+                dest_path = os.path.join(os.getcwd(), ".")
+            else:
+                dest_path = os.path.join(os.getcwd(), dest_fname)
 
             fileclient.copy(prev_path_full, dest_path)
 

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -102,7 +102,7 @@ class CopyFilesFromCalcLoc(FiretaskBase):
 
         fileclient = FileClient(filesystem=filesystem)
         calc_dir = fileclient.abspath(calc_dir)
-        filenames = self.get('filenames', None)
+        filenames = self.get('filenames')
         if filenames is None:
             files_to_copy = fileclient.listdir(calc_dir)
         elif isinstance(filenames, six.string_types):
@@ -110,7 +110,7 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         elif '$ALL_NO_SUBDIRS' in filenames:
             files_to_copy = fileclient.listdir(calc_dir)
         elif '$ALL' in filenames:
-            if self.get('name_prepend', None) or self.get('name_append', None):
+            if self.get('name_prepend') or self.get('name_append'):
                 raise ValueError('name_prepend or name_append options not compatible with "$ALL" option')
             fileclient.copytree(calc_dir, os.getcwd())
             return

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -103,19 +103,17 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         fileclient = FileClient(filesystem=filesystem)
         calc_dir = fileclient.abspath(calc_dir)
         filenames = self.get('filenames', None)
-        if filenames:
-            if isinstance(self["filenames"], six.string_types):
-                raise ValueError("filenames must be a list!")
-
-        if '$ALL_NO_SUBDIRS' in filenames:
+        if filenames is None:
+            files_to_copy = fileclient.listdir(calc_dir)
+        elif isinstance(filenames, six.string_types):
+            raise ValueError("filenames must be a list!")
+        elif '$ALL_NO_SUBDIRS' in filenames:
             files_to_copy = fileclient.listdir(calc_dir)
         elif '$ALL' in filenames:
             if self.get('name_prepend', None) or self.get('name_append', None):
                 raise ValueError('name_prepend or name_append options not compatible with "$ALL" option')
             fileclient.copytree(calc_dir, os.getcwd())
             return
-        else:
-            files_to_copy = filenames
 
         for f in files_to_copy:
             prev_path_full = os.path.join(calc_dir, f)

--- a/atomate/utils/fileio.py
+++ b/atomate/utils/fileio.py
@@ -121,6 +121,26 @@ class FileClient(object):
             else:
                 self.sftp.put(src, os.path.join(dest, os.path.basename(src)))
 
+    def copytree(self, src, dst, symlinks=False, ignore=None):
+        """
+        Recursively copy all files and subfolders from source to destination.
+            The difference with the original shutil.copytree is that dst folder
+            can already exist.
+
+        Args:
+            see shutil.copytree documentation
+        """
+        if not self.ssh:
+            for item in os.listdir(src):
+                s = os.path.join(src, item)
+                d = os.path.join(dst, item)
+                if os.path.isdir(s):
+                    shutil.copytree(s, d, symlinks, ignore)
+                else:
+                    shutil.copy2(s, d)
+        else:
+            raise NotImplementedError('copytree with ssh not implemented yet.')
+
     def abspath(self, path):
         """
         return the absolute path


### PR DESCRIPTION
## Summary

1) two args "name_prepend", "name_append" were coded to be optional but listed as required parameters.
2) added optional arg "keep_filenames" that is necessary if copying from subfolders. I may need this in subsequent AmsetFW PR. keep_filenames defaults to False so it is backwards-compatible. Please feel free to revert this commit if there's an issue with this.