### PR TITLE
use boltons.fileutils.copytree instead of the custom made copytree

### DIFF
--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -11,6 +11,7 @@ from fireworks import explicit_serialize, FiretaskBase, FWAction
 
 from atomate.utils.utils import env_chk, load_class, recursive_get_result
 from atomate.utils.fileio import FileClient
+from boltons.fileutils import copytree
 
 __author__ = 'Anubhav Jain'
 __email__ = 'ajain@lbl.gov'
@@ -112,7 +113,7 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         elif '$ALL' in filenames:
             if self.get('name_prepend') or self.get('name_append'):
                 raise ValueError('name_prepend or name_append options not compatible with "$ALL" option')
-            fileclient.copytree(calc_dir, os.getcwd())
+            copytree(calc_dir, os.getcwd())
             return
         else:
             files_to_copy = filenames

--- a/atomate/utils/fileio.py
+++ b/atomate/utils/fileio.py
@@ -121,26 +121,6 @@ class FileClient(object):
             else:
                 self.sftp.put(src, os.path.join(dest, os.path.basename(src)))
 
-    def copytree(self, src, dst, symlinks=False, ignore=None):
-        """
-        Recursively copy all files and subfolders from source to destination.
-            The difference with the original shutil.copytree is that dst folder
-            can already exist.
-
-        Args:
-            see shutil.copytree documentation
-        """
-        if not self.ssh:
-            for item in os.listdir(src):
-                s = os.path.join(src, item)
-                d = os.path.join(dst, item)
-                if os.path.isdir(s):
-                    shutil.copytree(s, d, symlinks, ignore)
-                else:
-                    shutil.copy2(s, d)
-        else:
-            raise NotImplementedError('copytree with ssh not implemented yet.')
-
     def abspath(self, path):
         """
         return the absolute path

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.35
 pandas==0.21.0
+boltons==17.2.0

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ if __name__ == "__main__":
                         'complete': ['paramiko>=1.15.0',
                                      'matplotlib>=1.5.2',
                                      'phonopy>=1.10.8',
+                                     'boltons>=17.2.0',
                                      ]},
         classifiers=['Programming Language :: Python :: 2.7',
                      "Programming Language :: Python :: 3",


### PR DESCRIPTION
- This brief PR is to address issue #193 to use boltons.fileutils.copytree instead of a previously custom defined copytree functions from shutil library. This has been tested with the '$ALL' option where copytree is actually called.

- boltons is added to requirements.txt and setup.py