### PR TITLE
use monty.shutil.copy_r instead of boltons.fileutils.copytree

### DIFF
--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-
 import six
 import monty
 import shutil
@@ -13,7 +12,7 @@ from fireworks import explicit_serialize, FiretaskBase, FWAction
 
 from atomate.utils.utils import env_chk, load_class, recursive_get_result
 from atomate.utils.fileio import FileClient
-from boltons.fileutils import copytree
+from monty.shutil import copy_r
 
 __author__ = 'Anubhav Jain'
 __email__ = 'ajain@lbl.gov'
@@ -115,7 +114,7 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         elif '$ALL' in filenames:
             if self.get('name_prepend') or self.get('name_append'):
                 raise ValueError('name_prepend or name_append options not compatible with "$ALL" option')
-            copytree(calc_dir, os.getcwd())
+            copy_r(calc_dir, os.getcwd())
             return
         else:
             files_to_copy = filenames

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.35
 pandas==0.22.0
-boltons==17.2.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         install_requires=['FireWorks>=1.4.0', 'pymatgen>=2017.12.15',
                           'custodian>=2017.12.23', 'monty>=1.0.2',
                           'tqdm>=4.7.4', 'six',
-                          'pymatgen-diffusion>=2018.1.4', 'boltons>=17.2.0'],
+                          'pymatgen-diffusion>=2018.1.4'],
         extras_require={'rtransfer': ['paramiko>=1.15.0'],
                         'plotting': ['matplotlib>=1.5.2'],
                         'phonons': ['phonopy>=1.10.8'],


### PR DESCRIPTION
## Summary

Used monty.shutil.copy_r instead of boltons.fileutils.copytree to remove boltons from requirements as it was the only use of boltons package at the moment.