### PR TITLE
wrong dash breaks `python setup.py develop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ M., Tang, H., Chu, I., Smidt, T., Bocklund, B., Horton, M., Dagdelen,
 J., Wood, B., Liu, Z.-K., Neaton, J., Ong, S. P., Persson, K., Jain, 
 A., Atomate: A high-level interface to generate, execute, and analyze 
 computational materials science workflows. Comput. Mater. Sci. 139, 
-140–152 (2017).
+140-152 (2017).
 ```


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "setup.py", line 15, in <module>
    long_description=open(os.path.join(module_dir, 'README.md')).read(),
  File "/global/u1/m/matcomp/mp_prod_atomate/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 912: ordinal not in range(128)
```