### PR TITLE
Small fix to additional_fields bug

### DIFF
--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -18,6 +18,7 @@ import glob
 import traceback
 
 from monty.io import zopen
+from monty.json import jsanitize
 
 import numpy as np
 
@@ -174,7 +175,7 @@ class VaspDrone(AbstractDrone):
         try:
             # basic properties, incl. calcs_reversed and run_stats
             fullpath = os.path.abspath(dir_name)
-            d = {k: v for k, v in self.additional_fields.items()}
+            d = jsanitize(self.additional_fields, strict=True)
             d["schema"] = {"code": "atomate", "version": VaspDrone.__version__}
             d["dir_name"] = fullpath
             d["calcs_reversed"] = [self.process_vasprun(dir_name, taskname, filename)


### PR DESCRIPTION
## Additional fields bug

If a user specifies an "additional_fields" kwarg to VaspToDb that's MSONable, fireworks serializes and deserializes the object, but the vasp drone doesn't, so when it's inserted into mongo or the json output, it's cast to a string, rather than an as_dict representation of the object.  This PR fixes by using jsanitize to recursively cast "additional_fields" to json at the beginning of the VASP output analysis.