### PR TITLE
update datetime.today to datetime.utcnow

### DIFF
--- a/atomate/feff/firetasks/parse_outputs.py
+++ b/atomate/feff/firetasks/parse_outputs.py
@@ -76,7 +76,7 @@ class SpectrumToDbTask(FiretaskBase):
                "edge": self.get("edge", None),
                "metadata": self.get("metadata", None),
                "dir_name": os.path.abspath(os.getcwd()),
-               "last_updated": datetime.today()}
+               "last_updated": datetime.utcnow()}
 
         if not db_file:
             with open("feff_task.json", "w") as f:

--- a/atomate/lammps/drones.py
+++ b/atomate/lammps/drones.py
@@ -127,7 +127,7 @@ class LammpsDrone(AbstractDrone):
             d["schema"] = {"code": "atomate", "version": LammpsDrone.__version__}
             d["completed_at"] = str(datetime.fromtimestamp(os.path.getmtime(log.log_file)))
             d["dir_name"] = fullpath
-            d["last_updated"] = datetime.today()
+            d["last_updated"] = datetime.utcnow()
             d["input"] = lmps_input.as_dict()
             d["output"] = {"log": log.as_dict()}
             d["output"]["dumps"] = dict([(dump_fname, dmp.as_dict()) for dump_fname, dmp in dumps])

--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -71,7 +71,7 @@ class CalcDb(six.with_metaclass(ABCMeta)):
         """
         result = self.collection.find_one({"dir_name": d["dir_name"]}, ["dir_name", "task_id"])
         if result is None or update_duplicates:
-            d["last_updated"] = datetime.datetime.today()
+            d["last_updated"] = datetime.datetime.utcnow()
             if result is None:
                 if ("task_id" not in d) or (not d["task_id"]):
                     d["task_id"] = self.db.counter.find_one_and_update(

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -295,7 +295,7 @@ class VaspDrone(AbstractDrone):
 
             self.set_analysis(d)
 
-            d["last_updated"] = datetime.datetime.today()
+            d["last_updated"] = datetime.datetime.utcnow()
             return d
 
         except Exception:


### PR DESCRIPTION
We're using datetime.utcnow() in most places and datetime.today() (which returns local system time without tz info) in some drones.  This PR changes all of those to datetime.utcnow().