### PR TITLE
explicit python-dateutil version req to address version conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   py3test:
     working_directory: ~/atomate
     docker:
-      - image: circleci/python:3.6.4
       - image: materialsvirtuallab/circle-ci-pmg-py3:0.0.2
       - image: circleci/mongo:3.4.15
     steps:
@@ -13,7 +12,7 @@ jobs:
       - run:
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
-            conda create --quiet --yes --name test_env python
+            conda create --quiet --yes --name test_env python=3.6
             source activate test_env
             conda install --quiet --yes numpy scipy matplotlib sympy pandas
             conda install --quiet --yes -c openbabel openbabel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   py3test:
     working_directory: ~/atomate
     docker:
+      - image: circleci/python:3.6.4
       - image: materialsvirtuallab/circle-ci-pmg-py3:0.0.2
       - image: circleci/mongo:3.4.15
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.40
 pandas==0.22.0
+python-dateutil==2.7.3
 pymatgen==2018.6.11
 custodian==2018.6.11


### PR DESCRIPTION
## Summary

Not ready to merge.

circle tests returned the following error that I suspect is due to dateutil version. I do not get this error locally. 

UnsatisfiableError: The following specifications were found to be in conflict:
  - pandas -> dateutil -> python 2.6* -> openssl 1.0.1*
  - pandas -> dateutil -> python 2.6* -> readline 6.2*
  - pandas -> dateutil -> python 2.6* -> tk 8.5*
  - python 3.7*