### PR TITLE
minute bug fix which makes vasp_cmd in an adsorption workflow use the…

### DIFF
--- a/atomate/vasp/workflows/base/adsorption.py
+++ b/atomate/vasp/workflows/base/adsorption.py
@@ -111,7 +111,7 @@ def get_wf_surface(slabs, molecules=[], bulk_structure=None, slab_gen_params=Non
 
     if bulk_structure:
         vis = MVLSlabSet(bulk_structure, bulk=True)
-        fws.append(OptimizeFW(structure=bulk_structure, vasp_input_set=vis, vasp_cmd="vasp", db_file=db_file))
+        fws.append(OptimizeFW(structure=bulk_structure, vasp_input_set=vis, vasp_cmd=vasp_cmd, db_file=db_file))
         parents = fws[0]
 
     for slab in slabs:


### PR DESCRIPTION
… correct argument

## Summary
Within the vasp/workflows/base/adsorption.py file, several functions which create workflows are detailed. vasp_cmd is accepted as an argument for each of them, with a default value of "vasp". However, in one of these functions, a call is made to another workflow function which uses vasp_cmd as an argument, which defaults to 'vasp', when it should be 'vasp_cmd' to use the same variable as was passed to the parent function. This changes literally that one line of code. :)

The current form is: (error encased in asterisks)
 ```

def get_wf_surface(slabs, molecules=[], bulk_structure=None, slab_gen_params=None, vasp_cmd="vasp",
                   db_file=None, ads_structures_params={}, add_molecules_in_box=False):
    """
    Docstring omitted
    """
    fws, parents = [], []

    if bulk_structure:
        vis = MVLSlabSet(bulk_structure, bulk=True)
        fws.append(OptimizeFW(structure=bulk_structure, vasp_input_set=vis, **vasp_cmd="vasp"**, db_file=db_file))
        parents = fws[0]
```

 It should read (change asterisked):
```

def get_wf_surface(slabs, molecules=[], bulk_structure=None, slab_gen_params=None, vasp_cmd="vasp",
                   db_file=None, ads_structures_params={}, add_molecules_in_box=False):
    """
    Docstring omitted
    """
    fws, parents = [], []

    if bulk_structure:
        vis = MVLSlabSet(bulk_structure, bulk=True)
        fws.append(OptimizeFW(structure=bulk_structure, vasp_input_set=vis, **vasp_cmd=vasp_cmd,** db_file=db_file))
        parents = fws[0]
```


