### PR TITLE
Refactor QChem file names and update requirements

### DIFF
--- a/atomate/lammps/drones.py
+++ b/atomate/lammps/drones.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import six
 
 from pymatgen.apps.borg.hive import AbstractDrone
-from pymatgen.io.lammps.output import LammpsLog, LammpsDump, LammpsRun
+# from pymatgen.io.lammps.output import LammpsLog, LammpsDump, LammpsRun
 # from pymatgen.io.lammps.sets import LammpsInputSet
 
 from atomate.utils.utils import get_uri

--- a/atomate/lammps/drones.py
+++ b/atomate/lammps/drones.py
@@ -12,7 +12,7 @@ import six
 
 from pymatgen.apps.borg.hive import AbstractDrone
 from pymatgen.io.lammps.output import LammpsLog, LammpsDump, LammpsRun
-from pymatgen.io.lammps.sets import LammpsInputSet
+# from pymatgen.io.lammps.sets import LammpsInputSet
 
 from atomate.utils.utils import get_uri
 

--- a/atomate/lammps/firetasks/__init__.py
+++ b/atomate/lammps/firetasks/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from .write_inputs import *
-from .run_calc import *
-from .parse_outputs import *
-from .glue_tasks import *
+# from .write_inputs import *
+# from .run_calc import *
+# from .parse_outputs import *
+# from .glue_tasks import *
 

--- a/atomate/lammps/firetasks/run_calc.py
+++ b/atomate/lammps/firetasks/run_calc.py
@@ -9,7 +9,7 @@ This module defines firetasks for running lammps
 import os
 import shutil
 
-from pymatgen.io.lammps.utils import PackmolRunner, LammpsRunner
+# from pymatgen.io.lammps.utils import PackmolRunner, LammpsRunner
 
 from fireworks import explicit_serialize, FiretaskBase, FWAction
 

--- a/atomate/lammps/firetasks/write_inputs.py
+++ b/atomate/lammps/firetasks/write_inputs.py
@@ -11,7 +11,7 @@ import six
 
 from pymatgen import Molecule
 from pymatgen.io.lammps.data import LammpsData
-from pymatgen.io.lammps.sets import LammpsInputSet
+# from pymatgen.io.lammps.sets import LammpsInputSet
 
 from fireworks import FiretaskBase, explicit_serialize
 

--- a/atomate/lammps/firetasks/write_inputs.py
+++ b/atomate/lammps/firetasks/write_inputs.py
@@ -10,7 +10,7 @@ parameters file)
 import six
 
 from pymatgen import Molecule
-from pymatgen.io.lammps.data import LammpsData
+# from pymatgen.io.lammps.data import LammpsData
 # from pymatgen.io.lammps.sets import LammpsInputSet
 
 from fireworks import FiretaskBase, explicit_serialize

--- a/atomate/lammps/fireworks/__init__.py
+++ b/atomate/lammps/fireworks/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-from .core import *
+# from .core import *

--- a/atomate/lammps/fireworks/core.py
+++ b/atomate/lammps/fireworks/core.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 Defines fireworks to be incorporated into workflows.
 """
 
-from pymatgen.io.lammps.data import Topology
+# from pymatgen.io.lammps.data import Topology
 
 from fireworks import Firework
 

--- a/atomate/lammps/tests/test_drone.py
+++ b/atomate/lammps/tests/test_drone.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 import os
 import unittest
 
-from pymatgen.io.lammps.sets import LammpsInputSet
+# from pymatgen.io.lammps.sets import LammpsInputSet
 from pymatgen.io.lammps.output import LammpsLog
 
 from atomate.utils.testing import AtomateTest

--- a/atomate/lammps/tests/test_drone.py
+++ b/atomate/lammps/tests/test_drone.py
@@ -5,7 +5,7 @@ import os
 import unittest
 
 # from pymatgen.io.lammps.sets import LammpsInputSet
-from pymatgen.io.lammps.output import LammpsLog
+# from pymatgen.io.lammps.output import LammpsLog
 
 from atomate.utils.testing import AtomateTest
 from atomate.lammps.drones import LammpsDrone

--- a/atomate/lammps/workflows/__init__.py
+++ b/atomate/lammps/workflows/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-from .core import *
+# from .core import *

--- a/atomate/lammps/workflows/core.py
+++ b/atomate/lammps/workflows/core.py
@@ -8,7 +8,7 @@ This module defines functions that yield lammps workflows
 
 from fireworks import Workflow
 
-from pymatgen.io.lammps.sets import LammpsInputSet
+# from pymatgen.io.lammps.sets import LammpsInputSet
 from pymatgen.io.lammps.data import Topology
 
 from atomate.lammps.fireworks.core import LammpsFW, PackmolFW, LammpsForceFieldFW

--- a/atomate/lammps/workflows/core.py
+++ b/atomate/lammps/workflows/core.py
@@ -9,7 +9,7 @@ This module defines functions that yield lammps workflows
 from fireworks import Workflow
 
 # from pymatgen.io.lammps.sets import LammpsInputSet
-from pymatgen.io.lammps.data import Topology
+# from pymatgen.io.lammps.data import Topology
 
 from atomate.lammps.fireworks.core import LammpsFW, PackmolFW, LammpsForceFieldFW
 

--- a/atomate/qchem/drones.py
+++ b/atomate/qchem/drones.py
@@ -13,8 +13,8 @@ from itertools import chain
 
 from monty.io import zopen
 from monty.json import jsanitize
-from pymatgen.io.qchem_io.outputs import QCOutput
-from pymatgen.io.qchem_io.inputs import QCInput
+from pymatgen.io.qchem.outputs import QCOutput
+from pymatgen.io.qchem.inputs import QCInput
 from pymatgen.apps.borg.hive import AbstractDrone
 from pymatgen.io.babel import BabelMolAdaptor
 from pymatgen.symmetry.analyzer import PointGroupAnalyzer

--- a/atomate/qchem/firetasks/run_calc.py
+++ b/atomate/qchem/firetasks/run_calc.py
@@ -9,11 +9,11 @@ import shutil
 import os
 import subprocess
 
-from pymatgen.io.qchem_io.inputs import QCInput
+from pymatgen.io.qchem.inputs import QCInput
 
 from custodian import Custodian
-from custodian.qchem.new_handlers import QChemErrorHandler
-from custodian.qchem.new_jobs import QCJob
+from custodian.qchem.handlers import QChemErrorHandler
+from custodian.qchem.jobs import QCJob
 
 from fireworks import explicit_serialize, FiretaskBase
 

--- a/atomate/qchem/firetasks/tests/test_run_calc.py
+++ b/atomate/qchem/firetasks/tests/test_run_calc.py
@@ -14,9 +14,9 @@ from atomate.qchem.firetasks.run_calc import RunQChemCustodian
 from atomate.qchem.firetasks.run_calc import RunQChemDirect
 from atomate.qchem.firetasks.run_calc import RunQChemFake
 from atomate.utils.testing import AtomateTest
-from custodian.qchem.new_handlers import QChemErrorHandler
-from custodian.qchem.new_jobs import QCJob
-from pymatgen.io.qchem_io.outputs import QCOutput
+from custodian.qchem.handlers import QChemErrorHandler
+from custodian.qchem.jobs import QCJob
+from pymatgen.io.qchem.outputs import QCOutput
 import numpy as np
 
 __author__ = "Samuel Blau"

--- a/atomate/qchem/firetasks/tests/test_write_inputs.py
+++ b/atomate/qchem/firetasks/tests/test_write_inputs.py
@@ -88,7 +88,7 @@ class TestWriteInputQChem(AtomateTest):
             "method": "wB97xd",
             "geom_opt_max_cycles": 200,
             "gen_scfman": True,
-            "scf_algorithm": "diis"
+            "scf_algorithm": "gdm"
         }
         qc_input = QCInput(mol, rem)
         ft = WriteInput(qc_input=qc_input)
@@ -106,7 +106,7 @@ class TestWriteInputQChem(AtomateTest):
             "method": "wB97xd",
             "geom_opt_max_cycles": 200,
             "gen_scfman": True,
-            "scf_algorithm": "diis"
+            "scf_algorithm": "gdm"
         }
         ft = WriteCustomInput(molecule=mol, rem=rem)
         ft.run_task({})

--- a/atomate/qchem/firetasks/tests/test_write_inputs.py
+++ b/atomate/qchem/firetasks/tests/test_write_inputs.py
@@ -9,7 +9,7 @@ import shutil
 from atomate.qchem.firetasks.write_inputs import WriteInputFromIOSet, WriteInput, WriteCustomInput
 from atomate.utils.testing import AtomateTest
 from pymatgen.core import Molecule
-from pymatgen.io.qchem_io.inputs import QCInput
+from pymatgen.io.qchem.inputs import QCInput
 
 __author__ = "Brandon Wood"
 __email__ = "b.wood@berkeley.edu"

--- a/atomate/qchem/firetasks/write_inputs.py
+++ b/atomate/qchem/firetasks/write_inputs.py
@@ -8,7 +8,7 @@ import os
 
 from atomate.utils.utils import load_class
 from fireworks import FiretaskBase, explicit_serialize
-from pymatgen.io.qchem_io.inputs import QCInput
+from pymatgen.io.qchem.inputs import QCInput
 
 __author__ = "Brandon Wood"
 __copyright__ = "Copyright 2018, The Materials Project"

--- a/atomate/qchem/firetasks/write_inputs.py
+++ b/atomate/qchem/firetasks/write_inputs.py
@@ -57,12 +57,12 @@ class WriteInputFromIOSet(FiretaskBase):
         # if a molecule is being passed through fw_spec
         elif fw_spec.get("prev_calc_molecule"):
             mol = fw_spec.get("prev_calc_molecule")
-            qcin_cls = load_class("pymatgen.io.qchem_io.sets",
+            qcin_cls = load_class("pymatgen.io.qchem.sets",
                                   self["qchem_input_set"])
             qcin = qcin_cls(mol, **self.get("qchem_input_params", {}))
         # if a molecule is included as an optional parameter
         elif self.get("molecule"):
-            qcin_cls = load_class("pymatgen.io.qchem_io.sets",
+            qcin_cls = load_class("pymatgen.io.qchem.sets",
                                   self["qchem_input_set"])
             qcin = qcin_cls(
                 self.get("molecule"), **self.get("qchem_input_params", {}))
@@ -84,7 +84,7 @@ class WriteCustomInput(FiretaskBase):
             qchem_input_custom (dict): Define custom input parameters to generate a qchem input file.
             This should be a dictionary of dictionaries (i.e. {{"rem": {"method": "b3lyp", basis": "6-31*G++", ...}
             Each QChem section should be a key with its own dictionary as the value. For more details on how
-            the input should be structured look at pymatgen.io.qchem_io.inputs
+            the input should be structured look at pymatgen.io.qchem.inputs
             ***  ***
 
         optional_params:

--- a/atomate/qchem/fireworks/tests/test_core.py
+++ b/atomate/qchem/fireworks/tests/test_core.py
@@ -10,7 +10,7 @@ from atomate.qchem.firetasks.run_calc import RunQChemCustodian
 from atomate.qchem.firetasks.parse_outputs import QChemToDb
 from atomate.qchem.fireworks.core import OptimizeFW, FrequencyFlatteningOptimizeFW
 from atomate.utils.testing import AtomateTest
-from pymatgen.io.qchem_io.outputs import QCOutput
+from pymatgen.io.qchem.outputs import QCOutput
 
 __author__ = "Samuel Blau"
 __copyright__ = "Copyright 2018, The Materials Project"

--- a/atomate/qchem/test_files/co_qc.in
+++ b/atomate/qchem/test_files/co_qc.in
@@ -11,5 +11,5 @@ $rem
    method = wB97xd
    geom_opt_max_cycles = 200
    gen_scfman = True
-   scf_algorithm = DIIS
+   scf_algorithm = gdm
 $end

--- a/atomate/qchem/test_files/to_opt.qin
+++ b/atomate/qchem/test_files/to_opt.qin
@@ -16,7 +16,7 @@ $rem
    METHOD  =  wb97xd
    JOB_TYPE  =  Opt
    gen_scfman = True
-   scf_algorithm = DIIS
+   scf_algorithm = gdm
    geom_opt_max_cycles = 200
    max_scf_cycles = 200
 $end

--- a/atomate/qchem/test_files/to_opt_pcm.qin
+++ b/atomate/qchem/test_files/to_opt_pcm.qin
@@ -16,7 +16,7 @@ $rem
    METHOD  =  wb97xd
    JOB_TYPE  =  Opt
    gen_scfman = True
-   scf_algorithm = DIIS
+   scf_algorithm = gdm
    geom_opt_max_cycles = 200
    max_scf_cycles = 200
    SOLVENT_METHOD  =  PCM

--- a/atomate/qchem/tests/test_powerups.py
+++ b/atomate/qchem/tests/test_powerups.py
@@ -11,7 +11,7 @@ from atomate.qchem.firetasks.run_calc import RunQChemDirect
 from atomate.qchem.firetasks.parse_outputs import QChemToDb
 from fireworks import Firework, Workflow
 from atomate.utils.testing import AtomateTest
-from pymatgen.io.qchem_io.outputs import QCOutput
+from pymatgen.io.qchem.outputs import QCOutput
 from atomate.qchem.powerups import use_fake_qchem
 
 __author__ = "Brandon Wood"

--- a/atomate/qchem/workflows/tests/test_double_FF_opt.py
+++ b/atomate/qchem/workflows/tests/test_double_FF_opt.py
@@ -46,7 +46,8 @@ class TestDoubleFFOpt(AtomateTest):
                 "basis_set": "6-311++g**",
                 "overwrite_inputs": {
                     "rem": {
-                        "sym_ignore": "true"
+                        "sym_ignore": "true",
+                        "scf_algorithm": "diis"
                     }
                 }
             })

--- a/atomate/qchem/workflows/tests/test_double_FF_opt.py
+++ b/atomate/qchem/workflows/tests/test_double_FF_opt.py
@@ -9,7 +9,7 @@ from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
 from atomate.utils.testing import AtomateTest
 from pymatgen.core import Molecule
-from pymatgen.io.qchem_io.inputs import QCInput
+from pymatgen.io.qchem.inputs import QCInput
 from atomate.qchem.powerups import use_fake_qchem
 from atomate.qchem.workflows.base.double_FF_opt import get_wf_double_FF_opt
 

--- a/atomate/qchem/workflows/tests/test_parse_pass_write.py
+++ b/atomate/qchem/workflows/tests/test_parse_pass_write.py
@@ -13,8 +13,8 @@ from fireworks import Firework, Workflow, FWorker
 from fireworks.core.rocket_launcher import rapidfire
 from atomate.utils.testing import AtomateTest
 from pymatgen.core import Molecule
-from pymatgen.io.qchem_io.outputs import QCOutput
-from pymatgen.io.qchem_io.inputs import QCInput
+from pymatgen.io.qchem.outputs import QCOutput
+from pymatgen.io.qchem.inputs import QCInput
 import numpy as np
 
 __author__ = "Brandon Wood"

--- a/atomate/qchem/workflows/tests/test_torsion_potential.py
+++ b/atomate/qchem/workflows/tests/test_torsion_potential.py
@@ -9,10 +9,10 @@ from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
 from atomate.utils.testing import AtomateTest
 from pymatgen.core import Molecule
-from pymatgen.io.qchem_io.outputs import QCOutput
+from pymatgen.io.qchem.outputs import QCOutput
 from atomate.qchem.workflows.base.torsion_potential import get_wf_torsion_potential
 from atomate.qchem.powerups import use_fake_qchem
-from pymatgen.io.qchem_io.inputs import QCInput
+from pymatgen.io.qchem.inputs import QCInput
 import numpy as np
 
 __author__ = "Brandon Wood"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
-pymatgen==2018.7.15
-custodian==2018.6.11
+pymatgen==2018.8.7
+-e git://github.com/materialsproject/custodian#egg=custodian
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
--e git://github.com/materialsproject/pymatgen#egg=pymatgen
+pymatgen==2018.8.10
 custodian==2018.8.10
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
--e git://github.com/samblau/pymatgen#egg=pymatgen
+-e git://github.com/materialsproject/pymatgen#egg=pymatgen
 custodian==2018.8.10
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
-pymatgen==2018.8.7
-custodian==2018.8.10
+-e git://github.com/samblau/pymatgen@qchem#egg=pymatgen
+-e git://github.com/espottesmith/custodian@qchem#egg=custodian
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
--e git://github.com/samblau/pymatgen@qchem#egg=pymatgen
+-e git://github.com/samblau/pymatgen#egg=pymatgen
 custodian==2018.8.10
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
 pymatgen==2018.8.7
--e git://github.com/materialsproject/custodian#egg=custodian
+custodian==2018.8.9
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
 -e git://github.com/samblau/pymatgen@qchem#egg=pymatgen
--e git://github.com/espottesmith/custodian@qchem#egg=custodian
+custodian==2018.8.10
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
--e git://github.com/materialsproject/pymatgen#egg=pymatgen
+pymatgen==2018.8.7
 custodian==2018.8.10
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.11.0
 pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
-pymatgen==2018.8.7
+-e git://github.com/materialsproject/pymatgen#egg=pymatgen
 custodian==2018.8.10
 networkx==2.1
 pydash==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ pybtex==0.21
 ruamel.yaml==0.15.44
 pandas==0.22.0
 pymatgen==2018.8.7
-custodian==2018.8.9
+custodian==2018.8.10
 networkx==2.1
 pydash==4.1.0


### PR DESCRIPTION
I noticed that my other pull request suddenly included freshly broken tests after merging the latest updates to Atomate and changing the requirement to the newly released Pymatgen version. Thus I wanted to isolate those tests from my fragmentation code that remains under development. I also want to get the QChem refactor complete across the three repos. Thus, this pull request:

- Refactors QChem file names in Pymatgen and Custodian
- Updates the requirements to the latest Pymatgen release and the current Custodian master

We will likely want to wait to merge this until we have a stable Custodian release. But let's see if these few small changes break tests. 