### PR TITLE
Add sanity check to CalcDb.from_db_file

### DIFF
--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -108,6 +108,12 @@ class CalcDb(six.with_metaclass(ABCMeta)):
             MMDb object
         """
         creds = loadfn(db_file)
+        
+        if admin and "admin_user" not in creds:
+            raise ValueError("Trying to use admin credentials, "
+                             "but no admin credentials are defined. "
+                             "Use admin=False if only read_only "
+                             "credentials are available.")
 
         if admin:
             user = creds.get("admin_user")

--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -109,7 +109,7 @@ class CalcDb(six.with_metaclass(ABCMeta)):
         """
         creds = loadfn(db_file)
         
-        if admin and "admin_user" not in creds:
+        if admin and "admin_user" not in creds and "readonly_user" in creds:
             raise ValueError("Trying to use admin credentials, "
                              "but no admin credentials are defined. "
                              "Use admin=False if only read_only "

--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -108,7 +108,7 @@ class CalcDb(six.with_metaclass(ABCMeta)):
             MMDb object
         """
         creds = loadfn(db_file)
-        
+
         if admin and "admin_user" not in creds and "readonly_user" in creds:
             raise ValueError("Trying to use admin credentials, "
                              "but no admin credentials are defined. "


### PR DESCRIPTION
## Summary

Previously no warning was issued if only read_only credentials were defined, leading to password not being set correctly. This leads to a confusing error message where `self.db.counter.find({"_id": "taskid"}).count()` fails due to an authentication error.

## TODO (if any)

None