### PR TITLE
add AmsetFW which has new RunAmset and AmsetToDb tasks

### DIFF
--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -269,14 +269,18 @@ class AmsetToDb(FiretaskBase):
     Optional params:
         db_file (str): path to file containing the database credentials.
             Supports env_chk. Default: write data to JSON file.
-        additional_fields (dict): fields added to the document such as user-defined tags or name, ids, etc
+        filename (str): the json filename from which the Amset run is loaded
+            via the from_file method.
+        additional_fields (dict): fields added to the document such as
+            user-defined tags or name, ids, etc
     """
 
     optional_params = ["db_file", "filename", "additional_fields"]
 
     def run_task(self, fw_spec):
         from amset.core import Amset
-        amset = Amset.from_file()
+        filename = self.get("filename", "amsetrun.json")
+        amset = Amset.from_file(filename=filename)
         additional_fields = self.get("additional_fields", {})
 
         # pass the additional_fields first to avoid overriding BoltztrapAnalyzer items

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -335,12 +335,11 @@ class AmsetToDb(FiretaskBase):
             amset_dict (dict): the output of Amset.from_file() method
 
         Returns (({[dict]}, [dict]):
-            For mobility (the first output): it is a dictionary containing
-                list of dicts for mobility vectors limited by various types of
-                scattering phenomena and the "overall" mobility at various
-                carrier concentration, c, and temperatures, T. The second
-                output is a list of dicts for seebeck coefficient also at
-                various c and T.
+            The first output (mobility) is a dictionary containing list of
+            dicts for mobility vectors limited by various types of scattering
+            phenomena and the "overall" mobility at various carrier
+            concentration, c, and temperatures, T. The second output is a list
+            of dicts for seebeck coefficient also at various c and T.
         """
         mobility = {}
         seebeck = []

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -343,7 +343,7 @@ class AmsetToDb(FiretaskBase):
                             "vec": d["seebeck"][tp][c][T],
                             "avg": np.mean(d["seebeck"][tp][c][T])
                         })
-        
+
         d["mobility"] = mobility
         d["seebeck"] = seebeck
         db_file = env_chk(self.get('db_file'), fw_spec)

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -317,6 +317,7 @@ class AmsetToDb(FiretaskBase):
         d["tags"] = list(set(d.get("tags", []) + fw_spec.get("tags", [])))
 
         # transform mobility and Seebeck coefficient to list of dicts:
+        # TODO: move this part to Amset for clearer input/output
         mobility = {}
         seebeck = []
         for itp, tp in enumerate(["p", "n"]):
@@ -342,6 +343,7 @@ class AmsetToDb(FiretaskBase):
                             "vec": d["seebeck"][tp][c][T],
                             "avg": np.mean(d["seebeck"][tp][c][T])
                         })
+        
         d["mobility"] = mobility
         d["seebeck"] = seebeck
         db_file = env_chk(self.get('db_file'), fw_spec)

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -292,7 +292,7 @@ class AmsetToDb(FiretaskBase):
             d["vbm"] = d["cbm_vbm"]["p"]
             d.pop("cbm_vbm")
         # add the structure
-        v, o = get_vasprun_outcar(d["dir_name"], parse_eigen=False, parse_dos=False)
+        v, _ = get_vasprun_outcar(d["dir_name"], parse_eigen=False, parse_dos=False)
         structure = v.final_structure
         d["structure"] = structure.as_dict()
         d["formula_pretty"] = structure.composition.reduced_formula

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -327,7 +327,8 @@ class AmsetToDb(FiretaskBase):
             mmdb = VaspCalcDb.from_db_file(db_file, admin=True)
             mmdb.db.amset.insert(d)
 
-    def reformat_mobility_seebeck(self, amset_dict):
+    @staticmethod
+    def reformat_mobility_seebeck(amset_dict):
         """
         Transforms mobility and Seebeck coefficient to list of dicts
 

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -264,23 +264,26 @@ class AmsetToDb(FiretaskBase):
     """
     Enter an Amset run into the database. Note that this assumes you are in a
     current directory that has the data with a sub-directory called "run_data"
-    containing the "amsetrun.json.gz" file (Amset run default filename).
+    containing the "amsetrun.json" file (Amset run default filename).
 
     Optional params:
         db_file (str): path to file containing the database credentials.
             Supports env_chk. Default: write data to JSON file.
+        dir_path (str): path to the folder where the amsetrun.json is present
+            defaults to None which is the current directory
         filename (str): the json filename from which the Amset run is loaded
             via the from_file method.
         additional_fields (dict): fields added to the document such as
             user-defined tags or name, ids, etc
     """
 
-    optional_params = ["db_file", "filename", "additional_fields"]
+    optional_params = ["db_file", "dir_path", "filename", "additional_fields"]
 
     def run_task(self, fw_spec):
         from amset.core import Amset
         filename = self.get("filename", "amsetrun.json")
-        amset = Amset.from_file(filename=filename)
+        dir_path = self.get("dir_path", None)
+        amset = Amset.from_file(path=dir_path, filename=filename)
         additional_fields = self.get("additional_fields", {})
 
         # pass the additional_fields first to avoid overriding BoltztrapAnalyzer items

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -262,6 +262,15 @@ class RunAmset(FiretaskBase):
             etc. See Amset documentation for key options
         temperatures ([float]): the temperatures (in Kelvin)
         doping: ([float]) doping levels you want to compute
+        kgrid_tp (str): determines how fine the k-point mesh is see Amset
+                documentation for options.
+        write_outputs (bool): whether to write various output files that Amset
+            generates such as .csv containing mobility and Seebeck coefficient,
+            the .json file containing all the run data and finally kgrid.json
+            and egrid.json.
+        write_inputs (bool): whether to write the 3 *_params dict inputs to
+            json files so that one can later examine the inputs used for a
+            completed run.
     """
     required_params = ["material_params"]
     optional_params = ["calc_dir", "model_params", "performance_params",

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -265,7 +265,7 @@ class RunAmset(FiretaskBase):
     """
     required_params = ["material_params"]
     optional_params = ["calc_dir", "model_params", "performance_params",
-                       "temperatures", "dopings", "coeff_file",
+                       "temperatures", "dopings",
                        "kgrid_tp", "write_outputs", "write_inputs"]
 
     def run_task(self, fw_spec):
@@ -278,7 +278,6 @@ class RunAmset(FiretaskBase):
         perfs["max_nbands"] = perfs.get("max_nbands", 1)
         temperatures = self.get("temperatures", None)
         dopings = self.get("dopings", None)
-        coeff_file = self.get("coeff_file", None)
         kgrid_tp = self.get("kgrid_tp", "coarse")
         write_outputs = self.get("write_outputs", True)
         write_inputs = self.get("write_inputs", True)
@@ -291,8 +290,7 @@ class RunAmset(FiretaskBase):
                        dopings=dopings,
                        temperatures=temperatures,
                        timeout=timeout)
-        runner.run_profiled(coeff_file=coeff_file,
-                            kgrid_tp=kgrid_tp)
+        runner.run_profiled(kgrid_tp=kgrid_tp)
         if write_outputs:
             runner.to_file()
             runner.to_csv()

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -259,13 +259,13 @@ class RunAmset(FiretaskBase):
         temperatures ([float]): the temperatures (in Kelvin)
         doping: ([float]) doping levels you want to compute
     """
-    from amset.core import Amset
     required_params = ["material_params"]
     optional_params = ["model_params", "performance_params",
                        "temperatures", "dopings", "coeff_file",
                        "kgrid_tp", "write_outputs", "write_inputs"]
 
     def run_task(self, fw_spec):
+        from amset.core import Amset
         material_params = self.get("material_params")
         model_params = self.get("model_params", None)
         perfs = self.get("performance_params", {})

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -271,11 +271,14 @@ class RunAmset(FiretaskBase):
         write_inputs (bool): whether to write the 3 *_params dict inputs to
             json files so that one can later examine the inputs used for a
             completed run.
+        timeout_hours (int): the maximum allowed time for Amset calculations
+            in hours. The calculations would be force stopped after this time
+            if not yet completed.
     """
     required_params = ["material_params"]
     optional_params = ["calc_dir", "model_params", "performance_params",
-                       "temperatures", "dopings",
-                       "kgrid_tp", "write_outputs", "write_inputs"]
+                       "temperatures", "dopings", "kgrid_tp", "write_outputs",
+                       "write_inputs", "timeout_hours"]
 
     def run_task(self, fw_spec):
         from amset.core import Amset
@@ -288,7 +291,7 @@ class RunAmset(FiretaskBase):
         kgrid_tp = self.get("kgrid_tp", "coarse")
         write_outputs = self.get("write_outputs", True)
         write_inputs = self.get("write_inputs", True)
-        timeout = self.get("timeout", 10)
+        timeout_hours = self.get("timeout_hours", 24)
 
         runner = Amset(calc_dir=calc_dir,
                        material_params=material_params,
@@ -296,7 +299,7 @@ class RunAmset(FiretaskBase):
                        performance_params=performance_params,
                        dopings=dopings,
                        temperatures=temperatures,
-                       timeout=timeout)
+                       timeout_hours=timeout_hours)
         runner.run_profiled(kgrid_tp=kgrid_tp)
         if write_outputs:
             runner.to_file()

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -245,7 +245,9 @@ class RunBoltztrap(FiretaskBase):
 @explicit_serialize
 class RunAmset(FiretaskBase):
     """
-    Run Amset directly.
+    Run Amset directly. For more information on input parameters, particularly
+    the options available in *_params dictionary see the documentations for
+    Amset: https://github.com/hackingmaterials/amset
 
     Required params:
         material_params (dict): the static dielectric constant (epsilon_s) is

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -245,13 +245,15 @@ class RunBoltztrap(FiretaskBase):
 @explicit_serialize
 class RunAmset(FiretaskBase):
     """
-    Run Amset directly. Requires vasprun.xml to be in current dir.
+    Run Amset directly.
 
     Required params:
         material_params (dict): the static dielectric constant (epsilon_s) is
             mandatory.
 
     Optional params:
+        calc_dir (str): the path to the folder that contains "vasprun.xml" and
+            where the logfile is written. Current directory by default.
         model_params (dict): parameters related to the model used and the level
             of theory. See Amset documentation for key options.
         performance_params (dict): parameters related to convergence, speed,
@@ -260,12 +262,13 @@ class RunAmset(FiretaskBase):
         doping: ([float]) doping levels you want to compute
     """
     required_params = ["material_params"]
-    optional_params = ["model_params", "performance_params",
+    optional_params = ["calc_dir", "model_params", "performance_params",
                        "temperatures", "dopings", "coeff_file",
                        "kgrid_tp", "write_outputs", "write_inputs"]
 
     def run_task(self, fw_spec):
         from amset.core import Amset
+        calc_dir = self.get("calc_dir", ".")
         material_params = self.get("material_params")
         model_params = self.get("model_params", None)
         perfs = self.get("performance_params", {})
@@ -279,7 +282,7 @@ class RunAmset(FiretaskBase):
         write_inputs = self.get("write_inputs", True)
         timeout = self.get("timeout", 10)
 
-        runner = Amset(calc_dir='.',
+        runner = Amset(calc_dir=calc_dir,
                        material_params=material_params,
                        model_params=model_params,
                        performance_params=perfs,

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -8,7 +8,7 @@ from monty.serialization import loadfn
 from atomate.vasp.config import HALF_KPOINTS_FIRST_RELAX
 
 """
-This module defines tasks that support running vasp in various ways or run 
+This module defines tasks that support running vasp in various ways or run
 other software packages that require vasp outputs: BoltzTraP, AMSET.
 """
 

--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -282,9 +282,7 @@ class RunAmset(FiretaskBase):
         calc_dir = self.get("calc_dir", ".")
         material_params = self.get("material_params")
         model_params = self.get("model_params", None)
-        perfs = self.get("performance_params", {})
-        perfs["max_nvalleys"] = perfs.get("max_nvalleys", 3)
-        perfs["max_nbands"] = perfs.get("max_nbands", 1)
+        performance_params = self.get("performance_params", None)
         temperatures = self.get("temperatures", None)
         dopings = self.get("dopings", None)
         kgrid_tp = self.get("kgrid_tp", "coarse")
@@ -295,7 +293,7 @@ class RunAmset(FiretaskBase):
         runner = Amset(calc_dir=calc_dir,
                        material_params=material_params,
                        model_params=model_params,
-                       performance_params=perfs,
+                       performance_params=performance_params,
                        dopings=dopings,
                        temperatures=temperatures,
                        timeout=timeout)

--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -719,7 +719,7 @@ class AmsetFW(Firework):
     def __init__(self, material_params, performance_params=None, model_params=None,
                  parents=None, structure=None, name="amset", db_file=None,
                  dopings=None, temperatures=None,  kgrid_tp="coarse",
-                 prev_calc_dir=None, additional_fields=None, timeout=10,
+                 prev_calc_dir=None, additional_fields=None, timeout=24,
                  **kwargs):
         """
         Run Amset (electronic transport calculation package)


### PR DESCRIPTION
## Summary

* I used AmsetFW by adding it after a "nscf uniform" firework. It uses the vasprun.xml from this calculation similar to BoltztrapFW; it also has RunAmset and AmsetToDb very similar to BoltztrapFW 
* AmsetToDb: the mobility and seebeck values are stored as list of jsons that contain the carrier concentration (c) and the temperature (T) at which the property is calculated as well as the actual vector ("vec") and average ("avg") of the calculated vector.
* unlike BoltzTrapFW, Amset is not under pymatgen and is not and should not be an atomate requirement. Therefore, the way I addressed this is to import Amset right under run_task as opposed to the top of the file (hence those who don't have Amset installed won't get ImportError).