### PR TITLE
Add wf_bandstructure_no_opt workflow

### DIFF
--- a/atomate/vasp/workflows/base/library/bandstructure_no_opt.yaml
+++ b/atomate/vasp/workflows/base/library/bandstructure_no_opt.yaml
@@ -1,0 +1,12 @@
+# A typical band structure
+# Author: Alex Ganose (aganose@lbl.gov)
+fireworks:
+- fw: atomate.vasp.fireworks.core.StaticFW
+- fw: atomate.vasp.fireworks.core.NonSCFFW
+  params:
+    parents: 0
+    mode: uniform
+- fw: atomate.vasp.fireworks.core.NonSCFFW
+  params:
+    parents: 0
+    mode: line

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -53,6 +53,29 @@ def wf_bandstructure(structure, c=None):
 
     return wf
 
+
+def wf_bandstructure_no_opt(structure, c=None):
+
+    c = c or {}
+    vasp_cmd = c.get("VASP_CMD", VASP_CMD)
+    db_file = c.get("DB_FILE", DB_FILE)
+
+    wf = get_wf(structure, "bandstructure_no_opt.yaml",
+                vis=MPStaticSet(structure, force_gamma=True),
+                common_params={"vasp_cmd": vasp_cmd, "db_file": db_file})
+
+    wf = add_common_powerups(wf, c)
+
+    if c.get("SMALLGAP_KPOINT_MULTIPLY", SMALLGAP_KPOINT_MULTIPLY):
+        wf = add_small_gap_multiply(wf, 0.5, 5, "static")
+        wf = add_small_gap_multiply(wf, 0.5, 5, "nscf")
+
+    if c.get("ADD_WF_METADATA", ADD_WF_METADATA):
+        wf = add_wf_metadata(wf, structure)
+
+    return wf
+
+
 def wf_bandstructure_hse(structure, c=None):
 
     c = c or {}


### PR DESCRIPTION
## Summary

Adds a workflow to run a band structure without performing a structure optimization beforehand.

This workflow is a direct copy of the `wf_bandstructure` workflow, with the relaxation step removed.

Tagging @tschaume as he is interested in using this workflow.