### PR TITLE
Fix custodian stored data (From issue #262)

### DIFF
--- a/atomate/vasp/firetasks/run_calc.py
+++ b/atomate/vasp/firetasks/run_calc.py
@@ -204,7 +204,8 @@ class RunVaspCustodian(FiretaskBase):
         c.run()
 
         if os.path.exists(zpath("custodian.json")):
-            return FWAction(stored_data=loadfn(zpath("custodian.json")))
+            stored_custodian_data = {"custodian": loadfn(zpath("custodian.json"))}
+            return FWAction(stored_data=stored_custodian_data)
 
 
 @explicit_serialize


### PR DESCRIPTION
I was having errors with fireworks fizzling due to incorrect saving of the custodian.json.

Looks like the error was brought up in issue #262, but not corrected. This seems to be the agreed upon fix from the discussions.