### PR TITLE
CalcDB from_file method now supports SSL

### DIFF
--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -135,7 +135,7 @@ class CalcDb(six.with_metaclass(ABCMeta)):
 
         # Remove keys which may cause collision when calling MongoClient
         for key in list(kwargs.keys()):
-            if key not in ['ssl','ssl_ca_certs','ssl_pem_passphrase','ssl_keyfile']:
+            if key not in ['ssl','ssl_ca_certs','ssl_ca_certfile','ssl_pem_passphrase','ssl_keyfile']:
                 del kwargs[key]
         
         return cls(creds["host"], int(creds["port"]), creds["database"], creds["collection"],

--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -125,11 +125,19 @@ class CalcDb(six.with_metaclass(ABCMeta)):
             user = creds.get("readonly_user")
             password = creds.get("readonly_password")
 
-        kwargs = {}
+        kwargs = dict(creds)
         if "authsource" in creds:
             kwargs["authsource"] = creds["authsource"]
         else:
             kwargs["authsource"] = creds["database"]
+        if 'ssl' in creds:
+            kwargs['ssl'] = bool(creds['ssl'])
+
+        # Remove keys which may cause collision when calling MongoClient
+        for key in ['host','port','database','collection','admin_password','admin_user',
+               'readonly_user','readonly_password','password','username']:
+            if key in kwargs:
+                del kwargs[key]
 
         return cls(creds["host"], int(creds["port"]), creds["database"], creds["collection"],
                    user, password, **kwargs)

--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -135,7 +135,7 @@ class CalcDb(six.with_metaclass(ABCMeta)):
 
         # Remove keys which may cause collision when calling MongoClient
         for key in list(kwargs.keys()):
-            if key not in ['ssl','ssl_ca_certs','ssl_ca_certfile','ssl_pem_passphrase','ssl_keyfile']:
+            if key not in ['authsource','ssl','ssl_ca_certs','ssl_ca_certfile','ssl_pem_passphrase','ssl_keyfile']:
                 del kwargs[key]
         
         return cls(creds["host"], int(creds["port"]), creds["database"], creds["collection"],

--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -134,10 +134,9 @@ class CalcDb(six.with_metaclass(ABCMeta)):
             kwargs['ssl'] = bool(creds['ssl'])
 
         # Remove keys which may cause collision when calling MongoClient
-        for key in ['host','port','database','collection','admin_password','admin_user',
-               'readonly_user','readonly_password','password','username']:
-            if key in kwargs:
+        for key in list(kwargs.keys()):
+            if key not in ['ssl','ssl_ca_certs','ssl_pem_passphrase','ssl_keyfile']:
                 del kwargs[key]
-
+        
         return cls(creds["host"], int(creds["port"]), creds["database"], creds["collection"],
                    user, password, **kwargs)


### PR DESCRIPTION
## Summary
This pull request is for a bug which I identified and patched in this google groups link:
https://groups.google.com/forum/#!topic/atomate/7D8Cc4xyiLw

Briefly summarized, the issue is: (a full explanation at the link above)
- The from_db method in the CalcDB method cannot take in arguments beyond what is explicitly listed in the function.
- This interferes with users who are using the CalcDB method as a part of workflows which ingest the results of calculations into databases which e.g. require SSL to enter.
And my fix is:
+ I have updated the method to improve flexibility with input SSL parameters.
+ I anticipated and addressed a potential bug in which the kwargs passed to the MongoClient instantiation collide with other arguments already hard-coded to be passed in, and so I remove the keys in the kwargs dictionary which produce a 'collision'; this also solves the problem of unexpected kwargs which could raise an error.Therefore, I decided a safer way to allow SSL support was through a 'whitelist', which would be less likely to break people's installations.


As I mentioned before, I don't know if unsolicited pull requests are welcome for tiny bug fixes, but hopefully you can accept this contribution.