### PR TITLE
fix: CalcDb: pass the authsource to db.authenticate

### DIFF
--- a/atomate/utils/database.py
+++ b/atomate/utils/database.py
@@ -42,7 +42,8 @@ class CalcDb(six.with_metaclass(ABCMeta)):
             raise Exception
         try:
             if self.user:
-                self.db.authenticate(self.user, self.password)
+                self.db.authenticate(self.user, self.password,
+                                     source=kwargs.get("authsource", None))
         except:
             logger.error("Mongodb authentication failed")
             raise ValueError


### PR DESCRIPTION
## Summary

Currently, I'm running into issues connecting to MongoDB Atlas databases when loading a `VaspCalcDb` from a `db.json` file, because the `"authsource": "admin"` key is only used in the initialization of the `MongoClient` in `CalcDb.__init__()`. However, when the authentication is tested on line 45, the "authsource" kwarg is no longer used, resulting in a Authentication failure when the database is queried later (specifically at line 53). By checking if `kwargs` has an "authsource" key and passing the corresponding value - or the default source (`None`) if not - the problem is fixed.

## TODO

As the credentials are now supplied in the initialization of the `MongoClient`since commit 02eb9a4932c18ef8155f8334a814bfc3d897bce2, is the `db.authenticate` line still necessary? In case it's only there to check the authentication credentials, I suppose we could also just put the try-except block around the final lines of the method, i.e.

```
try:
    # set counter collection
    if self.db.counter.find({"_id": "taskid"}).count() == 0:
        self.db.counter.insert_one({"_id": "taskid", "c": 0})
        self.build_indexes()
except:
    logger.error("Mongodb authentication failed")
    raise ValueError
```
Any authentication errors should be caught here as well, right? Of course, maybe there is some other reason for the `db.authenticate` line, I'm definitely not a `pymongo` expert. :)
