### PR TITLE
Fixed lazy import (Broken in pymatgen 2019.9.12)

### DIFF
--- a/atomate/vasp/firetasks/glue_tasks.py
+++ b/atomate/vasp/firetasks/glue_tasks.py
@@ -3,7 +3,8 @@
 import glob
 
 from pymatgen.analysis.elasticity.strain import Strain
-from pymatgen.io.vasp import Vasprun, zpath
+from pymatgen.io.vasp import Vasprun
+from monty.os.path import zpath
 
 """
 This module defines tasks that acts as a glue between other vasp Firetasks to allow communication


### PR DESCRIPTION
Updates to init in pymatgen.io.vasp breaks some of the imports used.