### PR TITLE
Update Google Groups references to Discourse

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 Please submit help issues to:
-https://groups.google.com/forum/#!forum/atomate
+https://hackingmaterials.discourse.group/c/atomate
 
 The Github issues is no longer used except for internal development purposes.
 
-If you are unable to use the Google Group, you may submit an issue here, but you must **clearly** state the reason you are unable to use the Google Group in your ticket. Otherwise, your issue will be **closed** without response.
+If you are unable to use the Discourse forum, you may submit an issue here, but you must **clearly** state the reason you are unable to use the Discourse forum in your ticket. Otherwise, your issue will be **closed** without response.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We love your input! We want to make contributing to atomate as easy and transpar
 * Becoming a maintainer
 
 ## Reporting bugs, getting help, and discussion
-At any time, feel free to start a thread on our [Google Group](https://groups.google.com/forum/#!forum/atomate).
+At any time, feel free to start a thread on our [Discourse forum](https://hackingmaterials.discourse.group/c/atomate).
 
 If you are making a bug report, incorporate as many elements of the following as possible to ensure a timely response and avoid the need for followups:
 * A quick summary and/or background
@@ -35,10 +35,10 @@ We have a few tips for writing good PRs that are accepted into the main repo:
 * Your code should have (4) spaces instead of tabs.
 * If needed, update the documentation.
 * **Write tests** for new features! Good tests are 100%, absolutely necessary for good code. We use the python `unittest` framework -- see some of the other tests in this repo for examples, or review the [Hitchhiker's guide to python](https://docs.python-guide.org/writing/tests/) for some good resources on writing good tests.
-* Understand your contributions will fall under the same license as this repo. 
+* Understand your contributions will fall under the same license as this repo.
 
-When you submit your PR, our CI service will automatically run your tests. 
+When you submit your PR, our CI service will automatically run your tests.
 We welcome good discussion on the best ways to write your code, and the comments on your PR are an excellent area for discussion.
 
 #### References
-This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62). 
+This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We love your input! We want to make contributing to atomate as easy and transpar
 * Becoming a maintainer
 
 ## Reporting bugs, getting help, and discussion
-At any time, feel free to start a thread on our [Discourse forum](https://hackingmaterials.discourse.group/c/atomate).
+At any time, feel free to start a thread on our [Discourse forum](https://discuss.matsci.org/c/atomate).
 
 If you are making a bug report, incorporate as many elements of the following as possible to ensure a timely response and avoid the need for followups:
 * A quick summary and/or background

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 atomate is a software for computational materials science that contains pre-built workflows to compute and analyze the properties of materials.
 
 - **Website (including documentation):** https://hackingmaterials.github.io/atomate/
-- **Help/Support:** https://hackingmaterials.discourse.group/c/atomate
+- **Help/Support:** https://discuss.matsci.org/c/atomate
 - **Source:** https://github.com/hackingmaterials/atomate
 
 If you find atomate useful, please encourage its development by citing the following paper in your research output:
 
 ```
-Mathew, K., Montoya, J. H., Faghaninia, A., Dwarakanath, S., Aykol, 
-M., Tang, H., Chu, I., Smidt, T., Bocklund, B., Horton, M., Dagdelen, 
-J., Wood, B., Liu, Z.-K., Neaton, J., Ong, S. P., Persson, K., Jain, 
-A., Atomate: A high-level interface to generate, execute, and analyze 
-computational materials science workflows. Comput. Mater. Sci. 139, 
+Mathew, K., Montoya, J. H., Faghaninia, A., Dwarakanath, S., Aykol,
+M., Tang, H., Chu, I., Smidt, T., Bocklund, B., Horton, M., Dagdelen,
+J., Wood, B., Liu, Z.-K., Neaton, J., Ong, S. P., Persson, K., Jain,
+A., Atomate: A high-level interface to generate, execute, and analyze
+computational materials science workflows. Comput. Mater. Sci. 139,
 140-152 (2017).
 ```

--- a/docs_rst/creating_workflows.rst
+++ b/docs_rst/creating_workflows.rst
@@ -302,6 +302,6 @@ Understanding this guide has enabled you to create arbitrarily complex atomate w
 
 If any of this was unclear, or if you feel that useful documentation is missing, please leave us feedback on the `atomate Discourse forum`_! To see all of the different pieces you can control with Python, go to the :ref:`API documentation <modindex>`. Many customization options and features of interest are not in atomate alone, but in `FireWorks`_, `pymatgen`_, and `custodian`_. Mastering FireWorks will enable you to get the most out of executing and managing your workflows. Mastering pymatgen will help you write complex materials workflows and perform sophisticated analyses of results.
 
-.. _atomate Discourse forum:  https://hackingmaterials.discourse.group/c/atomate
+.. _atomate Discourse forum:  https://discuss.matsci.org/c/atomate
 
 

--- a/docs_rst/creating_workflows.rst
+++ b/docs_rst/creating_workflows.rst
@@ -288,7 +288,7 @@ Currently supported ``env_chk`` variables are:
 * ``>>vasp_cmd<<``
 * ``>>db_file<<``
 
-If you think there are other potentially useful variables that should support ``env_chk``, please propose your idea in the `atomate Google Group`_ (or better, submit a pull request)!
+If you think there are other potentially useful variables that should support ``env_chk``, please propose your idea in the `atomate Discourse forum`_ (or better, submit a pull request)!
 
 PassCalcLocs
 ------------
@@ -300,8 +300,8 @@ Conclusion
 
 Understanding this guide has enabled you to create arbitrarily complex atomate workflows with any combination of Firetasks and Fireworks, but not everything was able to be covered in detail with examples. See the :ref:`customizing workflows` documentation for specific examples for customizing workflows that you can adapt to your needs.
 
-If any of this was unclear, or if you feel that useful documentation is missing, please leave us feedback on the `atomate Google Group`_! To see all of the different pieces you can control with Python, go to the :ref:`API documentation <modindex>`. Many customization options and features of interest are not in atomate alone, but in `FireWorks`_, `pymatgen`_, and `custodian`_. Mastering FireWorks will enable you to get the most out of executing and managing your workflows. Mastering pymatgen will help you write complex materials workflows and perform sophisticated analyses of results.
+If any of this was unclear, or if you feel that useful documentation is missing, please leave us feedback on the `atomate Discourse forum`_! To see all of the different pieces you can control with Python, go to the :ref:`API documentation <modindex>`. Many customization options and features of interest are not in atomate alone, but in `FireWorks`_, `pymatgen`_, and `custodian`_. Mastering FireWorks will enable you to get the most out of executing and managing your workflows. Mastering pymatgen will help you write complex materials workflows and perform sophisticated analyses of results.
 
-.. _atomate Google Group: https://groups.google.com/forum/#!forum/atomate
+.. _atomate Discourse forum:  https://hackingmaterials.discourse.group/c/atomate
 
 

--- a/docs_rst/index.rst
+++ b/docs_rst/index.rst
@@ -111,7 +111,7 @@ There is an `atomate Discourse forum`_ dedicated to discussion and basic support
 
 For specifics on how to contribute, see our `contribution guidelines. <https://github.com/hackingmaterials/atomate/blob/master/CONTRIBUTING.md>`_
 
-.. _atomate Discourse forum: https://hackingmaterials.discourse.group/c/atomate
+.. _atomate Discourse forum: https://discuss.matsci.org/c/atomate
 
 
 =======

--- a/docs_rst/index.rst
+++ b/docs_rst/index.rst
@@ -107,11 +107,11 @@ Want to see something added or changed? There are many ways to make that a reali
 
 The list of contributors to atomate can be found :doc:`here </contributors>`.
 
-There is an `atomate Google Group`_ dedicated to discussion and basic support.
+There is an `atomate Discourse forum`_ dedicated to discussion and basic support.
 
 For specifics on how to contribute, see our `contribution guidelines. <https://github.com/hackingmaterials/atomate/blob/master/CONTRIBUTING.md>`_
 
-.. _atomate Google Group: https://groups.google.com/forum/#!forum/atomate
+.. _atomate Discourse forum: https://hackingmaterials.discourse.group/c/atomate
 
 
 =======

--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -609,5 +609,5 @@ The non-reservation mode for qlaunching requires a little less maintenance with 
 Q: I honestly tried everything I can to solve my problem. I still need help!
 ----------------------------------------------------------------------------
 
-:A: There is a Google group for atomate: https://groups.google.com/forum/#!forum/atomate
+:A: There is a support forum for atomate: https://hackingmaterials.discourse.group/c/atomate
 

--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -609,5 +609,5 @@ The non-reservation mode for qlaunching requires a little less maintenance with 
 Q: I honestly tried everything I can to solve my problem. I still need help!
 ----------------------------------------------------------------------------
 
-:A: There is a support forum for atomate: https://hackingmaterials.discourse.group/c/atomate
+:A: There is a support forum for atomate: https://discuss.matsci.org/c/atomate
 


### PR DESCRIPTION
The Atomate support forum is moving from Google Groups to Discourse (https://hackingmaterials.discourse.group/c/fireworks). I've updated all references to Google Groups to point to the new forum.

Once merged, the docs should be regenerated to reflect the updates.