### PR TITLE
Add set_walltime powerup

### DIFF
--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -292,6 +292,28 @@ def clear_modify(original_wf, fw_name_constraint=None):
         original_wf.fws[idx_fw].tasks.pop(idx_t)
     return original_wf
 
+def set_walltime(original_wf, walltime=None, 
+                          fw_name_constraint=None, task_name_constraint=None):
+    """
+    set _queueadapter walltime spec of Fireworker(s) of a Workflow. It can be used to specify the walltime
+    requested from a queue on a per-workflow basis.
+
+    Args:
+        original_wf (Workflow):
+        walltime (str): user-defined walltime to be added under fw.spec._queueadapter['walltime']
+            in HH:MM:SS format e.g., "00:10:00" for 10 minutes.
+        fw_name_constraint (str): name of the Fireworks to be tagged (all if None is passed)
+        task_name_constraint (str): name of the Firetasks to be tagged (e.g. None or 'RunVasp')
+
+    Returns:
+        Workflow: modified workflow with specified walltime
+    """
+    for idx_fw, idx_t in get_fws_and_tasks(original_wf,
+                                           fw_name_constraint=fw_name_constraint,
+                                           task_name_constraint=task_name_constraint):
+        if walltime:
+            original_wf.fws[idx_fw].spec.update({"_queueadapter":{"walltime":walltime}})
+    return original_wf
 
 def set_execution_options(original_wf, fworker_name=None, category=None,
                           fw_name_constraint=None, task_name_constraint=None):

--- a/atomate/vasp/workflows/presets/scan.py
+++ b/atomate/vasp/workflows/presets/scan.py
@@ -37,7 +37,6 @@ def wf_scan_opt(structure, c=None):
             "max_force_threshold": 0,
             "half_kpts_first_relax": half_kpts,
             "job_type": "metagga_opt_run",
-            "db_file": db_file,
             "vasp_cmd": vasp_cmd
         })
     wf = add_common_powerups(wf, c)

--- a/atomate/vasp/workflows/presets/scan.py
+++ b/atomate/vasp/workflows/presets/scan.py
@@ -37,6 +37,7 @@ def wf_scan_opt(structure, c=None):
             "max_force_threshold": 0,
             "half_kpts_first_relax": half_kpts,
             "job_type": "metagga_opt_run",
+            "db_file": db_file,
             "vasp_cmd": vasp_cmd
         })
     wf = add_common_powerups(wf, c)


### PR DESCRIPTION
## Summary

This commit adds a new powerup that allows walltime to be specified on a per-workflow basis. Useful for tailoring queue submissions based on the expected demands of the specific workflow being run.