### PR TITLE
Add set_queue_options powerup

### DIFF
--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -293,7 +293,41 @@ def clear_modify(original_wf, fw_name_constraint=None):
         original_wf.fws[idx_fw].tasks.pop(idx_t)
     return original_wf
 
+def set_queue_options(original_wf, walltime=None,time_min=None,qos=None, 
+                          fw_name_constraint=None, task_name_constraint=None):
+    """
+    Modify queue submission parameters of Fireworks in a Workflow. 
+    
+    This powerup overrides paramters in the qadapter file by setting values in the 'queueadapter' key of a Firework spec. For example, the walltime
+    requested from a queue can be modified on a per-workflow basis.
 
+    Args:
+        original_wf (Workflow):
+        walltime (str): Total walltime to request for the job in HH:MM:SS format e.g., "00:10:00" for 10 minutes.
+        time_min (str): Minimum walltime to request in HH:MM:SS format. Specifying both `walltime` and `time_min` can improve throughput on some queues.
+        qos (str): QoS level to request. Typical examples include "regular", "flex", and "scavenger". For Cori KNL "flex" QoS, it is necessary to specify a `time_min` of no more than 2 hours.
+        fw_name_constraint (str): name of the Fireworks to be tagged (all if None is passed)
+        task_name_constraint (str): name of the Firetasks to be tagged (e.g. None or 'RunVasp')
+
+    Returns:
+        Workflow: workflow with modified queue options
+    """
+    qsettings = {}
+    if walltime:
+        qsettings.update({"walltime":walltime})
+    if time_min:
+        qsettings.update({"time_min":time_min})
+    if qos:
+        qsettings.update({"qos":qos})
+
+    for idx_fw, idx_t in get_fws_and_tasks(original_wf,
+                                           fw_name_constraint=fw_name_constraint,
+                                           task_name_constraint=task_name_constraint):
+        
+        original_wf.fws[idx_fw].spec.update({"_queueadapter":qsettings})
+
+    return original_wf
+    
 def set_execution_options(original_wf, fworker_name=None, category=None,
                           fw_name_constraint=None, task_name_constraint=None):
     """

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -293,41 +293,50 @@ def clear_modify(original_wf, fw_name_constraint=None):
         original_wf.fws[idx_fw].tasks.pop(idx_t)
     return original_wf
 
-def set_queue_options(original_wf, walltime=None,time_min=None,qos=None, 
-                          fw_name_constraint=None, task_name_constraint=None):
+
+def set_queue_options(original_wf, walltime=None, time_min=None, qos=None,
+                      fw_name_constraint=None, task_name_constraint=None):
     """
-    Modify queue submission parameters of Fireworks in a Workflow. 
-    
-    This powerup overrides paramters in the qadapter file by setting values in the 'queueadapter' key of a Firework spec. For example, the walltime
+    Modify queue submission parameters of Fireworks in a Workflow.
+
+    This powerup overrides paramters in the qadapter file by setting values in
+    the 'queueadapter' key of a Firework spec. For example, the walltime
     requested from a queue can be modified on a per-workflow basis.
 
     Args:
         original_wf (Workflow):
-        walltime (str): Total walltime to request for the job in HH:MM:SS format e.g., "00:10:00" for 10 minutes.
-        time_min (str): Minimum walltime to request in HH:MM:SS format. Specifying both `walltime` and `time_min` can improve throughput on some queues.
-        qos (str): QoS level to request. Typical examples include "regular", "flex", and "scavenger". For Cori KNL "flex" QoS, it is necessary to specify a `time_min` of no more than 2 hours.
-        fw_name_constraint (str): name of the Fireworks to be tagged (all if None is passed)
-        task_name_constraint (str): name of the Firetasks to be tagged (e.g. None or 'RunVasp')
+            walltime (str): Total walltime to request for the job in HH:MM:SS
+            format e.g., "00:10:00" for 10 minutes.
+        time_min (str): Minimum walltime to request in HH:MM:SS format.
+            Specifying both `walltime` and `time_min` can improve throughput on
+            some queues.
+        qos (str): QoS level to request. Typical examples include "regular",
+            "flex", and "scavenger". For Cori KNL "flex" QoS, it is necessary
+            to specify a `time_min` of no more than 2 hours.
+        fw_name_constraint (str): name of the Fireworks to be tagged (all if
+            None is passed)
+        task_name_constraint (str): name of the Firetasks to be tagged (e.g.
+            None or 'RunVasp')
 
     Returns:
         Workflow: workflow with modified queue options
     """
     qsettings = {}
     if walltime:
-        qsettings.update({"walltime":walltime})
+        qsettings.update({"walltime": walltime})
     if time_min:
-        qsettings.update({"time_min":time_min})
+        qsettings.update({"time_min": time_min})
     if qos:
-        qsettings.update({"qos":qos})
+        qsettings.update({"qos": qos})
 
     for idx_fw, idx_t in get_fws_and_tasks(original_wf,
                                            fw_name_constraint=fw_name_constraint,
                                            task_name_constraint=task_name_constraint):
-        
-        original_wf.fws[idx_fw].spec.update({"_queueadapter":qsettings})
+
+        original_wf.fws[idx_fw].spec.update({"_queueadapter": qsettings})
 
     return original_wf
-    
+
 def set_execution_options(original_wf, fworker_name=None, category=None,
                           fw_name_constraint=None, task_name_constraint=None):
     """

--- a/atomate/vasp/tests/test_vasp_powerups.py
+++ b/atomate/vasp/tests/test_vasp_powerups.py
@@ -6,7 +6,7 @@ from fireworks import Firework, ScriptTask, Workflow
 
 from atomate.vasp.powerups import add_priority, use_custodian, add_trackers, \
     add_modify_incar, add_small_gap_multiply, use_scratch_dir, remove_custodian, \
-    add_tags, add_wf_metadata, add_modify_potcar, clean_up_files
+    add_tags, add_wf_metadata, add_modify_potcar, clean_up_files, set_queue_options
 from atomate.vasp.workflows.base.core import get_wf
 
 from pymatgen.io.vasp.sets import MPRelaxSet
@@ -162,6 +162,24 @@ class TestVaspPowerups(unittest.TestCase):
                     v_found += 1
         self.assertEqual(b_found, 1)
         self.assertEqual(v_found, 4)
+
+    def test_queue_options(self):
+        my_wf = self._copy_wf(self.bs_wf)
+        my_wf = set_queue_options(my_wf, walltime="00:10:00")
+        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["walltime"],"00:10:00")
+
+        my_wf = self._copy_wf(self.bs_wf)
+        my_wf = set_queue_options(my_wf, qos="flex")
+        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["qos"],"flex")
+
+        my_wf = self._copy_wf(self.bs_wf)
+        my_wf = set_queue_options(my_wf, time_min="00:02:00")
+        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["time_min"],"00:02:00")
+
+        y_wf = set_queue_options(my_wf, walltime="00:10:00",time_min="00:02:00",qos="flex")
+        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["qos"],"flex")
+        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["time_min"],"00:02:00")
+        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["walltime"],"00:10:00")
 
     def test_add_wf_metadata(self):
         my_wf = self._copy_wf(self.bs_wf)

--- a/atomate/vasp/tests/test_vasp_powerups.py
+++ b/atomate/vasp/tests/test_vasp_powerups.py
@@ -166,20 +166,27 @@ class TestVaspPowerups(unittest.TestCase):
     def test_queue_options(self):
         my_wf = self._copy_wf(self.bs_wf)
         my_wf = set_queue_options(my_wf, walltime="00:10:00")
-        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["walltime"],"00:10:00")
+        for fw in my_wf.fws:
+            self.assertEqual(fw.spec["_queueadapter"]["walltime"], "00:10:00")
 
         my_wf = self._copy_wf(self.bs_wf)
         my_wf = set_queue_options(my_wf, qos="flex")
-        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["qos"],"flex")
+        for fw in my_wf.fws:
+            self.assertEqual(fw.spec["_queueadapter"]["qos"], "flex")
 
         my_wf = self._copy_wf(self.bs_wf)
         my_wf = set_queue_options(my_wf, time_min="00:02:00")
-        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["time_min"],"00:02:00")
+        for fw in my_wf.fws:
+            self.assertEqual(fw.spec["_queueadapter"]["time_min"], "00:02:00")
 
-        y_wf = set_queue_options(my_wf, walltime="00:10:00",time_min="00:02:00",qos="flex")
-        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["qos"],"flex")
-        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["time_min"],"00:02:00")
-        self.assertEqual(my_wf.id_fw[-1].spec["_queueadapter"]["walltime"],"00:10:00")
+        my_wf = self._copy_wf(self.bs_wf)
+        my_wf = set_queue_options(
+            my_wf, walltime="00:10:00", time_min="00:02:00", qos="flex"
+        )
+        for fw in my_wf.fws:
+            self.assertEqual(fw.spec["_queueadapter"]["qos"], "flex")
+            self.assertEqual(fw.spec["_queueadapter"]["time_min"], "00:02:00")
+            self.assertEqual(fw.spec["_queueadapter"]["walltime"], "00:10:00")
 
     def test_add_wf_metadata(self):
         my_wf = self._copy_wf(self.bs_wf)


### PR DESCRIPTION
## Summary

Added a powerup that allows the `walltime`, `time_min`, and `qos` queue submission options to be modified on a per-workflow basis. 

I did not make the powerup general (e.g., able to include arbitrary `SBATCH` arguments like number of nodes) because those changes would also require modification of the FWorker.

Tested and confirmed working on the Cori KNL queue. I'll note that I have only tested single-firework workflows. 
