### PR TITLE
Add ModifyKpoints Firetask and associated VASP powerup

### DIFF
--- a/atomate/vasp/firetasks/tests/test_write_vasp.py
+++ b/atomate/vasp/firetasks/tests/test_write_vasp.py
@@ -7,6 +7,7 @@ from atomate.vasp.firetasks.write_inputs import (
     WriteVaspFromPMGObjects,
     ModifyPotcar,
     ModifyIncar,
+    ModifyKpoints,
 )
 from atomate.utils.testing import AtomateTest
 
@@ -148,3 +149,18 @@ class TestWriteVasp(AtomateTest):
         new_potcar = Potcar.from_file("POTCAR")
         self.assertEqual(len(new_potcar), 1)
         self.assertEqual(new_potcar[0].symbol, "O")
+
+    def test_modify_kpoints(self):
+        # create an KPOINTS
+        kpoints = self.ref_kpoints
+        kpoints.write_file("KPOINTS")
+
+        # modify and test
+        ft = ModifyKpoints(
+            kpoints_update={"kpts": [[3,4,5]]},
+        )
+        ft = load_object(ft.to_dict())  # simulate database insertion
+        ft.run_task({})
+
+        kpoints_mod = Kpoints.from_file("KPOINTS")
+        self.assertEqual(kpoints_mod.kpts, [[3,4,5]])

--- a/atomate/vasp/firetasks/write_inputs.py
+++ b/atomate/vasp/firetasks/write_inputs.py
@@ -15,7 +15,7 @@ from fireworks.utilities.dict_mods import apply_mod
 from pymatgen.core.structure import Structure
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.alchemy.transmuters import StandardTransmuter
-from pymatgen.io.vasp import Incar, Poscar, Potcar, PotcarSingle
+from pymatgen.io.vasp import Incar, Poscar, Potcar, PotcarSingle, Kpoints
 from pymatgen.io.vasp.sets import (
     MPStaticSet,
     MPNonSCFSet,
@@ -207,6 +207,44 @@ class ModifyIncar(FiretaskBase):
             apply_mod(incar_dictmod, incar)
 
         incar.write_file(self.get("output_filename", "INCAR"))
+
+@explicit_serialize
+class ModifyKpoints(FiretaskBase):
+    """
+    Modify an KPOINTS file.
+
+    Required params:
+        (none)
+
+    Optional params:
+        kpoint_update (dict): overwrite Kpoint dict key. Supports env_chk.
+            keys can be anything property of a kpoint object (kpts, kpts_shift,
+            kpts_weights, labels, comment, coord_type, num_kpts,
+            tet_connections, tet_number, tet_weight)
+        input_filename (str): Input filename (if not "INCAR")
+        output_filename (str): Output filename (if not "INCAR")
+    """
+
+    optional_params = [
+        "incar_update",
+        "incar_multiply",
+        "incar_dictmod",
+        "input_filename",
+        "output_filename",
+    ]
+
+    def run_task(self, fw_spec):
+
+        kpoints_name = self.get("input_filename", "KPOINTS")
+        kpoint = Kpoints.from_file(kpoints_name)
+
+        incar_update = env_chk(self.get("incar_update"), fw_spec)
+
+        if incar_update:
+            for key, value in incar_update.items():
+                setattr(kpoint, key, value)
+
+        kpoint.write_file(self.get("output_filename", "KPOINTS"))
 
 
 @explicit_serialize

--- a/atomate/vasp/firetasks/write_inputs.py
+++ b/atomate/vasp/firetasks/write_inputs.py
@@ -217,7 +217,7 @@ class ModifyKpoints(FiretaskBase):
         (none)
 
     Optional params:
-        kpoint_update (dict): overwrite Kpoint dict key. Supports env_chk.
+        kpoints_update (dict): overwrite Kpoint dict key. Supports env_chk.
             keys can be anything property of a kpoint object (kpts, kpts_shift,
             kpts_weights, labels, comment, coord_type, num_kpts,
             tet_connections, tet_number, tet_weight)
@@ -226,9 +226,7 @@ class ModifyKpoints(FiretaskBase):
     """
 
     optional_params = [
-        "incar_update",
-        "incar_multiply",
-        "incar_dictmod",
+        "kpoints_update",
         "input_filename",
         "output_filename",
     ]
@@ -236,15 +234,15 @@ class ModifyKpoints(FiretaskBase):
     def run_task(self, fw_spec):
 
         kpoints_name = self.get("input_filename", "KPOINTS")
-        kpoint = Kpoints.from_file(kpoints_name)
+        kpoints = Kpoints.from_file(kpoints_name)
 
-        incar_update = env_chk(self.get("incar_update"), fw_spec)
+        kpoints_update = env_chk(self.get("kpoints_update"), fw_spec)
 
-        if incar_update:
-            for key, value in incar_update.items():
-                setattr(kpoint, key, value)
+        if kpoints_update:
+            for key, value in kpoints_update.items():
+                setattr(kpoints, key, value)
 
-        kpoint.write_file(self.get("output_filename", "KPOINTS"))
+        kpoints.write_file(self.get("output_filename", "KPOINTS"))
 
 
 @explicit_serialize

--- a/atomate/vasp/firetasks/write_inputs.py
+++ b/atomate/vasp/firetasks/write_inputs.py
@@ -221,8 +221,8 @@ class ModifyKpoints(FiretaskBase):
             keys can be anything property of a kpoint object (kpts, kpts_shift,
             kpts_weights, labels, comment, coord_type, num_kpts,
             tet_connections, tet_number, tet_weight)
-        input_filename (str): Input filename (if not "INCAR")
-        output_filename (str): Output filename (if not "INCAR")
+        input_filename (str): Input filename (if not "KPOINTS")
+        output_filename (str): Output filename (if not "KPOINTS")
     """
 
     optional_params = [

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -298,8 +298,8 @@ def add_modify_kpoints(
 
     Args:
         original_wf (Workflow)
-        modify_kpoints_params (dict) - dict of parameters for ModifyKpoints.
-        fw_name_constraint (str) - Only apply changes to FWs where fw_name
+        modify_kpoints_params (dict): dict of parameters for ModifyKpoints.
+        fw_name_constraint (str): Only apply changes to FWs where fw_name
         contains this substring.
 
     Returns:

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -14,7 +14,8 @@ from atomate.vasp.firetasks.run_calc import (
     RunNoVasp,
 )
 from atomate.vasp.firetasks.neb_tasks import RunNEBVaspFake
-from atomate.vasp.firetasks.write_inputs import ModifyIncar, ModifyPotcar
+from atomate.vasp.firetasks.write_inputs import ModifyIncar, ModifyPotcar, \
+    ModifyKpoints
 from atomate.vasp.firetasks.parse_outputs import JsonToDb
 from atomate.vasp.config import (
     ADD_NAMEFILE,
@@ -284,6 +285,37 @@ def add_modify_incar(
     for idx_fw, idx_t in idx_list:
         original_wf.fws[idx_fw].tasks.insert(
             idx_t, ModifyIncar(**modify_incar_params)
+        )
+    return original_wf
+
+def add_modify_kpoints(
+    original_wf, modify_kpoints_params=None, fw_name_constraint=None
+):
+    """
+    Every FireWork that runs VASP has a ModifyKpoints task just beforehand. For
+    example, allows you to modify the KPOINTS based on the Worker using env_chk
+    or using hard-coded changes.
+
+    Args:
+        original_wf (Workflow)
+        modify_kpoints_params (dict) - dict of parameters for ModifyKpoints.
+        fw_name_constraint (str) - Only apply changes to FWs where fw_name
+        contains this substring.
+
+    Returns:
+       Workflow
+    """
+    modify_kpoints_params = modify_kpoints_params or {
+        "kpoints_update": ">>kpoints_update<<"
+    }
+    idx_list = get_fws_and_tasks(
+        original_wf,
+        fw_name_constraint=fw_name_constraint,
+        task_name_constraint="RunVasp",
+    )
+    for idx_fw, idx_t in idx_list:
+        original_wf.fws[idx_fw].tasks.insert(
+            idx_t, ModifyKpoints(**modify_kpoints_params)
         )
     return original_wf
 

--- a/atomate/vasp/tests/test_vasp_powerups.py
+++ b/atomate/vasp/tests/test_vasp_powerups.py
@@ -14,6 +14,7 @@ from atomate.vasp.powerups import (
     add_tags,
     add_wf_metadata,
     add_modify_potcar,
+    add_modify_kpoints,
     clean_up_files,
     set_queue_options,
     use_potcar_spec,
@@ -95,6 +96,22 @@ class TestVaspPowerups(unittest.TestCase):
             else:
                 for t in fw.tasks:
                     self.assertFalse("ModifyIncar" in t["_fw_name"])
+
+    def test_modify_kpoints(self):
+        my_wf = add_modify_kpoints(
+            copy_wf(self.bs_wf),
+            {"kpoints_update": {"kpts": [[3,4,5]]}},
+            fw_name_constraint="structure optimization",
+        )
+
+        for fw in my_wf.fws:
+            if "structure optimization" in fw.name:
+                self.assertTrue("ModifyKpoints" in fw.tasks[1]._fw_name)
+                self.assertEqual(fw.tasks[1]["kpoints_update"],
+                                 {"kpts": [[3,4,5]]})
+            else:
+                for t in fw.tasks:
+                    self.assertFalse("ModifyKpoints" in t["_fw_name"])
 
     def test_modify_potcar(self):
         my_wf = add_modify_potcar(


### PR DESCRIPTION
## Summary
This was a useful feature for me, thought it might be useful for some other people.

Added the ModifyKpoints Firetask to modify a Kpoints object based on a dictionary that matches its attributes. Added an associated VASP powerup to do this at a workflow level.