### PR TITLE
Do not store volumetric data by default

### DIFF
--- a/atomate/vasp/config.py
+++ b/atomate/vasp/config.py
@@ -35,7 +35,7 @@ DEFUSE_UNSUCCESSFUL = "fizzle"
 CUSTODIAN_MAX_ERRORS = 5
 
 # store data from these files in database if present
-STORE_VOLUMETRIC_DATA = ("chgcar", "aeccar0", "aeccar2", "elfcar", "locpot")
+STORE_VOLUMETRIC_DATA = ()  # e.g. ("chgcar", "aeccar0", "aeccar2", "elfcar", "locpot")
 
 # ingest any additional JSON data present into database when parsing VASP directories
 # useful for storing duplicate of FW.json


### PR DESCRIPTION
## Summary

We were storing volumetric data by default under the same logic as storing band structure data. These were only stored if explicitly generated. However, given typical database size restrictions, it would be better to turn this off by default and enable on-demand.