### PR TITLE
Added extra_outcar_read argument to VaspDrone and VaspToDb.

### DIFF
--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -137,6 +137,11 @@ class VaspDrone(AbstractDrone):
         self.parse_potcar_file = parse_potcar_file
         self.extra_outcar_read = extra_outcar_read or []
 
+        for flag in self.extra_outcar_read:
+            if flag not in ["igpar", "lepsilon", "lcalcpol",
+                            "core_state_eigen", "avg_core_poten"]:
+                raise ValueError(f"Invalid value {flag} for extra_outcar_read.")
+
         if parse_chgcar or parse_aeccar:
             warnings.warn("These options have been deprecated in favor of the 'store_volumetric_data' "
                           "keyword argument, which is more general. Functionality is equivalent.",

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -60,6 +60,13 @@ class VaspToDb(FiretaskBase):
             Set to "line" for line mode. If not set, band structure will not
             be parsed.
         additional_fields (dict): dict of additional fields to add
+        extra_outcar_read (list of str): list of extra data to read from
+            outcars. Default to []. The following strings will work:
+            - "igpar" to call Outcar.read_igpar()
+            - "lepsilon" to call Outcar.read_lepsilon()
+            - "lcalcpol" to call Outcar.read_lcalcpol()
+            - "core_state_eigen" to call Outcar.read_core_state_eigen()
+            - "avg_core_poten" to call Outcar.read_avg_core_poten()
         db_file (str): path to file containing the database credentials.
             Supports env_chk. Default: write data to JSON file.
         fw_spec_field (str): if set, will update the task doc with the contents
@@ -80,7 +87,8 @@ class VaspToDb(FiretaskBase):
                        "additional_fields", "db_file", "fw_spec_field", "defuse_unsuccessful",
                        "task_fields_to_push", "parse_chgcar", "parse_aeccar",
                        "parse_potcar_file",
-                       "store_volumetric_data"]
+                       "store_volumetric_data",
+                       "extra_outcar_read"]
 
     def run_task(self, fw_spec):
         # get the directory that contains the VASP dir to parse
@@ -99,7 +107,8 @@ class VaspToDb(FiretaskBase):
                           bandstructure_mode=self.get("bandstructure_mode", False),
                           parse_chgcar=self.get("parse_chgcar", False),  # deprecated
                           parse_aeccar=self.get("parse_aeccar", False),  # deprecated
-                          store_volumetric_data=self.get("store_volumetric_data", STORE_VOLUMETRIC_DATA))
+                          store_volumetric_data=self.get("store_volumetric_data", STORE_VOLUMETRIC_DATA),
+                          extra_outcar_read=self.get("extra_outcar_read", []))
 
         # assimilate (i.e., parse)
         task_doc = drone.assimilate(calc_dir)

--- a/atomate/vasp/fireworks/polarization.py
+++ b/atomate/vasp/fireworks/polarization.py
@@ -149,7 +149,9 @@ class LcalcpolFW(Firework):
                 RunVaspCustodian(vasp_cmd=vasp_cmd),
                 PassCalcLocs(name=name),
                 VaspToDb(
-                    db_file=db_file, additional_fields={"task_label": name}
+                    db_file=db_file,
+                    additional_fields={"task_label": name},
+                    extra_outcar_read=["lcalcpol"],
                 ),
             ]
         )
@@ -157,6 +159,8 @@ class LcalcpolFW(Firework):
         # Note, Outcar must have read_lcalcpol method for polarization
         # information to be processed. ...assuming VaspDrone will automatically
         # assimilate all properties of the Outcar.
+        # Update: I haven't tested it for lack of input files, but VaspDrone
+        #  should use read_lcalcpol now - Andrew Bogdan (andrewbogdan@lbl.gov)
         super(LcalcpolFW, self).__init__(
             t,
             parents=parents,


### PR DESCRIPTION
## The Issue

Currently VaspDrone serializes OUTCARs with `Outcar.as_dict()`, which does't actually retrieve all the information from the OUTCAR.

In [pymatgen's documentation](https://pymatgen.org/pymatgen.io.vasp.outputs.html?highlight=outcar#pymatgen.io.vasp.outputs.Outcar):

> One can then call a specific reader depending on the type of run being performed. These are currently: read_igpar(), read_lepsilon() and read_lcalcpol(), read_core_state_eign(), read_avg_core_pot().

As far as I can tell, nowhere in atomate are these methods called, except for in the comment (from `atomate.vasp.fireworks.polarization.LcalcpolFW`):

    # Note, Outcar must have read_lcalcpol method for polarization
    # information to be processed. ...assuming VaspDrone will automatically
    # assimilate all properties of the Outcar.

Which, although I don't have the datafiles to test it, I don't believe it does.

## Changes

I added an argument `extra_outcar_read` to VaspDrone and VaspToDb which takes a list of strings. It accepts the following strings:
- `"igpar"`: Call `Outcar.read_igpar()`, storing it under `outcar_dict["igpar"]`.
- `"lepsilon"`: Call `Outcar.read_lepsilon()`, storing it under `outcar_dict["lepsilon"]`.
- `"lcalcpol"`: Call `Outcar.read_lcalcpol()`, storing it under `outcar_dict["lcalcpol"]`.
- `"core_state_eigen"`: Call `Outcar.read_core_state_eigen()`, storing it under `outcar_dict["core_state_eigen"]`.
- `"avg_core_poten"`: Call `Outcar.read_avg_core_poten()`, storing it under `outcar_dict["avg_core_poten"]`

I also edited LcaclpolFW to use `extra_outcar_read=["lcalcpol"]` in its VaspToDb task, although, as I said earlier, I don't have the proper datafiles to test if it works. I _did_ test it with `extra_outcar_read=["core_state_eigen"]`, as that's what prompted me to make this edit. It appears to work fine.