### PR TITLE
remove retired copy_to_current_on_exit kwarg from PackmolFW

### DIFF
--- a/atomate/lammps/firetasks/run_calc.py
+++ b/atomate/lammps/firetasks/run_calc.py
@@ -77,14 +77,12 @@ class RunPackmol(FiretaskBase):
         control_params (dict): packmol control parameters dictionary. Basically all parameters other
             than structure/atoms
         output_file (str): output file name. The extension will be adjusted according to the filetype
-        copy_to_current_on_exit (bool): whether or not to copy the packed molecule output file to
-            the current directory.
         site_property (str): the specified site property will be restored for the final Molecule object.
     """
 
     required_params = ["molecules", "packing_config", "packmol_cmd"]
     optional_params = ["tolerance", "filetype", "control_params", "output_file",
-                       "copy_to_current_on_exit", "site_property"]
+                       "site_property"]
 
     def run_task(self, fw_spec):
         pmr = PackmolRunner(self["molecules"], self["packing_config"],
@@ -94,6 +92,6 @@ class RunPackmol(FiretaskBase):
                             output_file=self.get("output_file", "packed_mol.xyz"),
                             bin=self["packmol_cmd"])
         logger.info("Running {}".format(self["packmol_cmd"]))
-        packed_mol = pmr.run(self.get("copy_to_current_on_exit", False), site_property=self.get("site_property", None))
+        packed_mol = pmr.run(site_property=self.get("site_property", None))
         logger.info("Packmol finished running.")
         return FWAction(mod_spec=[{'_set': {'packed_mol': packed_mol}}])

--- a/atomate/lammps/fireworks/core.py
+++ b/atomate/lammps/fireworks/core.py
@@ -114,8 +114,8 @@ class LammpsForceFieldFW(Firework):
 class PackmolFW(Firework):
 
     def __init__(self, molecules, packing_config, tolerance=2.0, filetype="xyz", control_params=None,
-                 output_file="packed.xyz",  copy_to_current_on_exit=False, site_property=None,
-                 parents=None, name="PackmolFW", packmol_cmd="packmol", **kwargs):
+                 output_file="packed.xyz", site_property=None, parents=None, name="PackmolFW",
+                 packmol_cmd="packmol", **kwargs):
         """
 
         Args:
@@ -128,8 +128,6 @@ class PackmolFW(Firework):
             control_params (dict): packmol control parameters dictionary. Basically all parameters
                 other than structure/atoms.
             output_file (str): output file name. The extension will be adjusted according to the filetype.
-            copy_to_current_on_exit (bool): whether or not to copy the packed molecule output file
-                to the current directory.
             site_property (str): the specified site property will be restored for the final Molecule object.
             parents ([Firework]): parent fireworks
             name (str): firework name
@@ -141,8 +139,7 @@ class PackmolFW(Firework):
         tasks = [
             RunPackmol(molecules=molecules, packing_config=packing_config, tolerance=tolerance,
                        filetype=filetype, control_params=control_params,  output_file=output_file,
-                       copy_to_current_on_exit=copy_to_current_on_exit, site_property=site_property,
-                       packmol_cmd=packmol_cmd),
+                       site_property=site_property, packmol_cmd=packmol_cmd),
 
             PassCalcLocs(name=name)
 

--- a/atomate/lammps/workflows/core.py
+++ b/atomate/lammps/workflows/core.py
@@ -116,7 +116,7 @@ def get_packmol_wf(input_file, user_settings, constituent_molecules, packing_con
 
     fw_packmol = PackmolFW(constituent_molecules, packing_config, tolerance=tolerance,
                            filetype=filetype, control_params=control_params,
-                           copy_to_current_on_exit=True, output_file=packmol_output_file,
+                           output_file=packmol_output_file,
                            site_property=ff_site_property, packmol_cmd=packmol_cmd)
 
     fws.append(fw_packmol)


### PR DESCRIPTION
Recent updates to the pymatgen `PackmolRunner` (see https://github.com/materialsproject/pymatgen/pull/1947) removed the `copy_to_current_on_exit` kwarg. This PR also removes the kwarg from `PackmolFW` and `RunPackmol`.