### PR TITLE
Allow no optimization before bulk modulus/thermal expansion workflows

### DIFF
--- a/atomate/vasp/workflows/base/bulk_modulus.py
+++ b/atomate/vasp/workflows/base/bulk_modulus.py
@@ -1,44 +1,53 @@
-# coding: utf-8
-
-
 """
 This module defines the bulk modulus workflow.
 """
 
 from uuid import uuid4
 
-from fireworks import Firework, Workflow
-
-from pymatgen.analysis.elasticity.strain import Deformation
-from pymatgen.io.vasp.sets import MPStaticSet
-
 from atomate.utils.utils import get_logger
 from atomate.vasp.firetasks.parse_outputs import FitEOSToDb
 from atomate.vasp.workflows.base.deformations import get_wf_deformations
+from fireworks import Firework, Workflow
+from pymatgen.analysis.elasticity.strain import Deformation
+from pymatgen.io.vasp.sets import MPStaticSet
 
-__author__ = 'Kiran Mathew'
-__email__ = 'kmathew@lbl.gov'
+__author__ = "Kiran Mathew"
+__email__ = "kmathew@lbl.gov"
 
 logger = get_logger(__name__)
 
 
-def get_wf_bulk_modulus(structure, deformations, vasp_input_set=None, vasp_cmd="vasp", db_file=None,
-                        user_kpoints_settings=None, eos="vinet", tag=None, user_incar_settings=None):
+def get_wf_bulk_modulus(
+    structure,
+    deformations,
+    vasp_input_set=None,
+    vasp_cmd="vasp",
+    db_file=None,
+    user_kpoints_settings=None,
+    eos="vinet",
+    tag=None,
+    copy_vasp_outputs=False,
+    user_incar_settings=None,
+):
     """
-    Returns the workflow that computes the bulk modulus by fitting to the given equation of state.
+    Returns the workflow that computes the bulk modulus by fitting to the given equation
+    of state.
 
     Args:
         structure (Structure): input structure.
-        deformations (list): list of deformation matrices(list of lists).
+        deformations (list): list of deformation matrices (list of lists).
         vasp_input_set (VaspInputSet): for the static deformation calculations
         vasp_cmd (str): vasp command to run.
         db_file (str): path to the db file.
         user_kpoints_settings (dict): example: {"grid_density": 7000}
         eos (str): equation of state used for fitting the energies and the volumes.
-            supported equation of states: "quadratic", "murnaghan", "birch", "birch_murnaghan",
-            "pourier_tarantola", "vinet", "deltafactor". See pymatgen.analysis.eos.py
-        tag (str): something unique to identify the tasks in this workflow. If None a random uuid
-            will be assigned.
+            supported equation of states: "quadratic", "murnaghan", "birch",
+            "birch_murnaghan", "pourier_tarantola", "vinet", "deltafactor".
+            See pymatgen.analysis.eos.py
+        tag (str): something unique to identify the tasks in this workflow. If None a
+            random uuid will be assigned.
+        copy_vasp_outputs (bool): whether or not copy the outputs from the previous calc
+            (usually structure optimization) before the deformations are performed.
         user_incar_settings (dict):
 
     Returns:
@@ -49,18 +58,31 @@ def get_wf_bulk_modulus(structure, deformations, vasp_input_set=None, vasp_cmd="
 
     deformations = [Deformation(defo_mat) for defo_mat in deformations]
 
-    vis_static = vasp_input_set or MPStaticSet(structure=structure, force_gamma=True, lepsilon=False,
-                                               user_kpoints_settings=user_kpoints_settings,
-                                               user_incar_settings=user_incar_settings)
+    vis_static = vasp_input_set or MPStaticSet(
+        structure=structure,
+        force_gamma=True,
+        user_kpoints_settings=user_kpoints_settings,
+        user_incar_settings=user_incar_settings,
+    )
 
-    wf_bulk_modulus = get_wf_deformations(structure, deformations, name="bulk_modulus deformation",
-                                          vasp_input_set=vis_static, vasp_cmd=vasp_cmd,
-                                          db_file=db_file, tag=tag)
+    wf_bulk_modulus = get_wf_deformations(
+        structure,
+        deformations,
+        name="bulk_modulus deformation",
+        vasp_input_set=vis_static,
+        vasp_cmd=vasp_cmd,
+        copy_vasp_outputs=copy_vasp_outputs,
+        db_file=db_file,
+        tag=tag,
+    )
 
-    fw_analysis = Firework(FitEOSToDb(tag=tag, db_file=db_file, eos=eos), name="fit equation of state")
+    fit_eos = FitEOSToDb(tag=tag, db_file=db_file, eos=eos)
+    fw_analysis = Firework(fit_eos, name="fit equation of state")
+    wf_analysis = Workflow.from_Firework(fw_analysis)
 
-    wf_bulk_modulus.append_wf(Workflow.from_Firework(fw_analysis), wf_bulk_modulus.leaf_fw_ids)
+    wf_bulk_modulus.append_wf(wf_analysis, wf_bulk_modulus.leaf_fw_ids)
 
-    wf_bulk_modulus.name = "{}:{}".format(structure.composition.reduced_formula, "Bulk modulus")
+    formula = structure.composition.reduced_formula
+    wf_bulk_modulus.name = "{}:{}".format(formula, "Bulk modulus")
 
     return wf_bulk_modulus

--- a/atomate/vasp/workflows/base/deformations.py
+++ b/atomate/vasp/workflows/base/deformations.py
@@ -1,61 +1,68 @@
-# coding: utf-8
-
-
 """
-This module defines the deformation workflow: structure optimization followed by transmuter fireworks.
+This module defines the deformation workflow.
 """
-
-from fireworks import Workflow
-
-from pymatgen.io.vasp.sets import MPStaticSet
 
 from atomate.utils.utils import get_logger
 from atomate.vasp.fireworks.core import TransmuterFW
+from fireworks import Workflow
+from pymatgen.io.vasp.sets import MPStaticSet
 
-__author__ = 'Kiran Mathew'
-__credits__ = 'Joseph Montoya'
-__email__ = 'kmathew@lbl.gov'
+__author__ = "Kiran Mathew"
+__credits__ = "Joseph Montoya"
+__email__ = "kmathew@lbl.gov"
 
 logger = get_logger(__name__)
 
 
-def get_wf_deformations(structure, deformations, name="deformation", vasp_input_set=None,
-                        vasp_cmd="vasp", db_file=None, tag="", copy_vasp_outputs=True, metadata=None):
+def get_wf_deformations(
+    structure,
+    deformations,
+    name="deformation",
+    vasp_input_set=None,
+    vasp_cmd="vasp",
+    db_file=None,
+    tag="",
+    copy_vasp_outputs=True,
+    metadata=None,
+):
     """
     Returns a structure deformation workflow.
 
-    Firework 1 : structural relaxation
-    Firework 2 - len(deformations): Deform the optimized structure and run static calculations.
-
+    Worfklow consists of: len(deformations) in which the structure is deformed followed
+    by a static calculation.
 
     Args:
         structure (Structure): input structure to be optimized and run
         deformations (list of 3x3 array-likes): list of deformations
         name (str): some appropriate name for the transmuter fireworks.
-        vasp_input_set (DictVaspInputSet): vasp input set for static deformed structure calculation.
+        vasp_input_set (DictVaspInputSet): vasp input set for static deformed structure
+            calculation.
         vasp_cmd (str): command to run
         db_file (str): path to file containing the database credentials.
-        tag (str): some unique string that will be appended to the names of the fireworks so that
-            the data from those tagged fireworks can be queried later during the analysis.
-        copy_vasp_outputs (bool): whether or not copy the outputs from the previous calc(usually
-            structure optimization) before the transmuter fireworks.
+        tag (str): some unique string that will be appended to the names of the
+            fireworks so that the data from those tagged fireworks can be queried later
+            during the analysis.
+        copy_vasp_outputs (bool): whether or not copy the outputs from the previous calc
+            (usually structure optimization) before the transmuter fireworks.
         metadata (dict): meta data
 
     Returns:
         Workflow
     """
-
-    fws, parents = [], []
-
     vasp_input_set = vasp_input_set or MPStaticSet(structure, force_gamma=True)
 
-    # Deformation fireworks with the task to extract and pass stress-strain appended to it.
+    fws = []
     for n, deformation in enumerate(deformations):
-        fw = TransmuterFW(name="{} {} {}".format(tag, name, n), structure=structure,
-                          transformations=['DeformStructureTransformation'],
-                          transformation_params=[{"deformation": deformation.tolist()}],
-                          vasp_input_set=vasp_input_set, copy_vasp_outputs=copy_vasp_outputs,
-                          parents=parents, vasp_cmd=vasp_cmd, db_file=db_file)
+        fw = TransmuterFW(
+            name="{} {} {}".format(tag, name, n),
+            structure=structure,
+            transformations=["DeformStructureTransformation"],
+            transformation_params=[{"deformation": deformation.tolist()}],
+            vasp_input_set=vasp_input_set,
+            copy_vasp_outputs=copy_vasp_outputs,
+            vasp_cmd=vasp_cmd,
+            db_file=db_file,
+        )
         fws.append(fw)
 
     wfname = "{}:{}".format(structure.composition.reduced_formula, name)

--- a/atomate/vasp/workflows/base/thermal_expansion.py
+++ b/atomate/vasp/workflows/base/thermal_expansion.py
@@ -24,7 +24,9 @@ logger = get_logger(__name__)
 
 def get_wf_thermal_expansion(structure, deformations, vasp_input_set=None, vasp_cmd="vasp",
                              db_file=None, user_kpoints_settings=None, t_step=10, t_min=0,
-                             t_max=1000, mesh=(20, 20, 20), eos="vinet", pressure=0.0, tag=None):
+                             t_max=1000, mesh=(20, 20, 20), eos="vinet", pressure=0.0,
+                             copy_vasp_outputs=False,
+                             tag=None):
     """
     Returns quasi-harmonic thermal expansion workflow.
     Note: phonopy package is required for the final analysis step.
@@ -43,6 +45,8 @@ def get_wf_thermal_expansion(structure, deformations, vasp_input_set=None, vasp_
         eos (str): equation of state used for fitting the energies and the volumes.
             options supported by phonopy: "vinet", "murnaghan", "birch_murnaghan".
             Note: pymatgen supports more options than phonopy. see pymatgen.analysis.eos.py
+        copy_vasp_outputs (bool): whether or not copy the outputs from the previous calc
+            (usually structure optimization) before the deformations are performed.
         pressure (float): in GPa
         tag (str): something unique to identify the tasks in this workflow. If None a random uuid
             will be assigned.
@@ -63,6 +67,7 @@ def get_wf_thermal_expansion(structure, deformations, vasp_input_set=None, vasp_
                                                user_kpoints_settings=user_kpoints_settings)
     wf_alpha = get_wf_deformations(structure, deformations, name="thermal_expansion deformation",
                                    vasp_cmd=vasp_cmd, db_file=db_file, tag=tag,
+                                   copy_vasp_outputs=copy_vasp_outputs,
                                    vasp_input_set=vis_static)
 
     fw_analysis = Firework(ThermalExpansionCoeffToDb(tag=tag, db_file=db_file, t_step=t_step,

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -490,7 +490,7 @@ def wf_bulk_modulus(structure, c=None):
     # get the deformations wflow for bulk modulus calculation
     wf_bm = get_wf_bulk_modulus(structure, eos=eos, user_kpoints_settings=user_kpoints_settings,
                                 deformations=deformations, vasp_cmd=vasp_cmd, db_file=db_file, tag=tag,
-                                vasp_input_set=vis_static)
+                                copy_vasp_outputs=True, vasp_input_set=vis_static)
 
     # chain it
     wf.append_wf(wf_bm, wf.leaf_fw_ids)

--- a/atomate/vasp/workflows/presets/core.py
+++ b/atomate/vasp/workflows/presets/core.py
@@ -542,6 +542,7 @@ def wf_thermal_expansion(structure, c=None):
 
     wf_thermal = get_wf_thermal_expansion(structure, user_kpoints_settings=user_kpoints_settings,
                                           deformations=deformations, vasp_cmd=vasp_cmd, db_file=db_file,
+                                          copy_vasp_outputs=True,
                                           eos=eos, pressure=pressure, tag=tag)
 
     # chain it


### PR DESCRIPTION
Fixes #445 

The `get_wf_bulk_modulus` and `get_wf_thermal_expansion` workflows assume that they will be appended to an OptimizeFW. If not, they fail because:
- They call `get_wf_deformations` with `copy_vasp_outputs=True`. Subsequently, when the deformation firework is run, there are no calc_locs in the firework spec to copy previous outputs from.
- The `FitEOSToDb` and `ThermalExpansionCoeffToDb` analysis FireTasks try and get the starting structure from a task with the `structure optimization` task label which doesn't exist in the workflow.

This PR addresses both issues by:
1. Adding a `copy_vasp_outputs` option to `get_wf_bulk_modulus` and `get_wf_thermal_expansion` which is passed through to the  `get_wf_deformations` and has a default value of `False`. 
2. Updating the analysis FireTasks to get the initial structure from the transformation history contained in the deformation task output rather than from a structure optimisation.