### PR TITLE
Change source of bandgap in SCAN workflow logic

### DIFF
--- a/atomate/vasp/firetasks/write_inputs.py
+++ b/atomate/vasp/firetasks/write_inputs.py
@@ -325,7 +325,7 @@ class WriteScanRelaxFromPrev(FiretaskBase):
             else:
                 parse_potcar_file = not potcar_spec
                 vasprun = Vasprun("vasprun.xml", parse_potcar_file=parse_potcar_file)
-                bandgap = vasprun.get_band_structure().get_band_gap()["energy"]
+                bandgap = vasprun.eigenvalue_band_properties[0]
                 vasp_input_set_params["bandgap"] = bandgap
 
         # read the structure from the output of the previous calculation


### PR DESCRIPTION
It has come to our attention that `Vasprun.get_band_structure().get_band_gap()["energy"]` can return an incorrect band gap in some cases. The bandgap is used to determine k-point density and smearing settings for SCAN calculations in `WriteScanRelaxFromPrev`. 

To make this firetask more robust, this PR switches the source of the bandgap information to `Vasprun.eigenvalue_band_properties[0]`.