### PR TITLE
Add eigenvalue_band_properties to VASP drone

### DIFF
--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -405,6 +405,19 @@ class VaspDrone(AbstractDrone):
                 logger.error(traceback.format_exc())
                 logger.error("Error in " + os.path.abspath(dir_name) + ".\n" + traceback.format_exc())
                 raise
+        
+        # Should roughly agree with information from .get_band_structure() above, subject to tolerances
+        # If there is disagreement, it may be related to VASP incorrectly assigning the Fermi level
+        try:
+            band_props = v.eigenvalue_band_properties
+            d["output"]["eigenvalue_band_properties"] = {
+                "bandgap": band_props[0],
+                "cbm": band_props[1],
+                "vbm": band_props[2],
+                "is_gap_direct": band_props[3]
+            }
+        except Exception:
+            logger.warning("Error in parsing eigenvalue band properties")
 
         # store run name and location ,e.g. relax1, relax2, etc.
         d["task"] = {"type": taskname, "name": taskname}

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -409,7 +409,7 @@ class VaspDrone(AbstractDrone):
         # Should roughly agree with information from .get_band_structure() above, subject to tolerances
         # If there is disagreement, it may be related to VASP incorrectly assigning the Fermi level
         try:
-            band_props = v.eigenvalue_band_properties
+            band_props = vrun.eigenvalue_band_properties
             d["output"]["eigenvalue_band_properties"] = {
                 "bandgap": band_props[0],
                 "cbm": band_props[1],

--- a/atomate/vasp/tests/test_drones.py
+++ b/atomate/vasp/tests/test_drones.py
@@ -98,7 +98,7 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             self.assertNotIn("transition",d)
             self.assertAlmostEqual(d["direct_gap"],2.5563)
             self.assertIn("bandstructure", doc["calcs_reversed"][0])
-        band_props = doc["output"]["eigenvalue_band_properties"]
+        band_props = doc["calcs_reversed"][0]["output"]["eigenvalue_band_properties"]
         self.assertAlmostEqual(band_props["bandgap"], 0.6505999999999998)
         self.assertAlmostEqual(band_props["cbm"], 6.2644)
         self.assertAlmostEqual(band_props["vbm"], 5.6138)

--- a/atomate/vasp/tests/test_drones.py
+++ b/atomate/vasp/tests/test_drones.py
@@ -98,6 +98,11 @@ class VaspToDbTaskDroneTest(unittest.TestCase):
             self.assertNotIn("transition",d)
             self.assertAlmostEqual(d["direct_gap"],2.5563)
             self.assertIn("bandstructure", doc["calcs_reversed"][0])
+        band_props = doc["output"]["eigenvalue_band_properties"]
+        self.assertAlmostEqual(band_props["bandgap"], 0.6505999999999998)
+        self.assertAlmostEqual(band_props["cbm"], 6.2644)
+        self.assertAlmostEqual(band_props["vbm"], 5.6138)
+        self.assertFalse(band_props["is_gap_direct"])
 
 
         doc = drone.assimilate(self.Al)


### PR DESCRIPTION
## Summary

An additive change, to help diagnose issues where band gap might be reported inconsistently from a Vasprun.