### PR TITLE
Make pymatgen import statements more specific

### DIFF
--- a/atomate/feff/firetasks/tests/test_tasks.py
+++ b/atomate/feff/firetasks/tests/test_tasks.py
@@ -6,7 +6,7 @@ import shutil
 import unittest
 from glob import glob
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.feff.sets import MPEXAFSSet
 from pymatgen.io.feff.inputs import Paths
 

--- a/atomate/feff/fireworks/tests/test_fireworks.py
+++ b/atomate/feff/fireworks/tests/test_fireworks.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import unittest
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from atomate.feff.fireworks.core import EXAFSPathsFW
 from atomate.utils.testing import AtomateTest

--- a/atomate/feff/workflows/tests/test_eels_workflows.py
+++ b/atomate/feff/workflows/tests/test_eels_workflows.py
@@ -4,7 +4,7 @@
 import os
 import unittest
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.feff.inputs import Tags
 
 from fireworks.core.fworker import FWorker

--- a/atomate/feff/workflows/tests/test_exafs_scattering_paths.py
+++ b/atomate/feff/workflows/tests/test_exafs_scattering_paths.py
@@ -4,7 +4,7 @@
 import os
 import unittest
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from atomate.feff.workflows.core import get_wf_exafs_paths
 

--- a/atomate/feff/workflows/tests/test_xas_workflows.py
+++ b/atomate/feff/workflows/tests/test_xas_workflows.py
@@ -6,7 +6,7 @@ import unittest
 
 import numpy as np
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.feff.inputs import Tags
 
 from fireworks.core.fworker import FWorker

--- a/atomate/lammps/firetasks/write_inputs.py
+++ b/atomate/lammps/firetasks/write_inputs.py
@@ -6,7 +6,7 @@ This module defines firetasks for writing LAMMPS input files (data file and the 
 parameters file)
 """
 
-from pymatgen import Molecule
+from pymatgen.core import Molecule
 # from pymatgen.io.lammps.data import LammpsData
 # from pymatgen.io.lammps.sets import LammpsInputSet
 

--- a/atomate/utils/testing.py
+++ b/atomate/utils/testing.py
@@ -10,7 +10,7 @@ from io import open
 from fireworks import LaunchPad
 from pymongo import MongoClient
 
-from pymatgen.settings import SETTINGS
+from pymatgen.core import SETTINGS
 
 __author__ = "Kiran Mathew"
 __credits__ = "Anubhav Jain"

--- a/atomate/utils/utils.py
+++ b/atomate/utils/utils.py
@@ -11,7 +11,7 @@ from time import time
 from pymongo import MongoClient
 from monty.json import MontyDecoder
 from monty.serialization import loadfn
-from pymatgen import Composition
+from pymatgen.core import Composition
 
 from fireworks import Workflow
 from pymatgen.alchemy.materials import TransformedStructure

--- a/atomate/vasp/builders/boltztrap_materials.py
+++ b/atomate/vasp/builders/boltztrap_materials.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 
 from atomate.utils.utils import get_logger , get_database
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.analysis.structure_matcher import StructureMatcher, ElementComparator
 from pymatgen.electronic_structure.boltztrap import BoltztrapAnalyzer
 

--- a/atomate/vasp/builders/file_materials.py
+++ b/atomate/vasp/builders/file_materials.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 
 from atomate.utils.utils import get_database
 
-from pymatgen import Composition
+from pymatgen.core import Composition
 
 from atomate.vasp.builders.base import AbstractBuilder
 from atomate.utils.utils import get_logger

--- a/atomate/vasp/builders/materials_descriptor.py
+++ b/atomate/vasp/builders/materials_descriptor.py
@@ -2,7 +2,7 @@ from tqdm import tqdm
 
 from atomate.utils.utils import get_database
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.analysis.structure_analyzer import get_dimensionality
 
 from atomate.utils.utils import get_logger

--- a/atomate/vasp/builders/materials_ehull.py
+++ b/atomate/vasp/builders/materials_ehull.py
@@ -5,7 +5,8 @@ from tqdm import tqdm
 
 from atomate.utils.utils import get_database
 
-from pymatgen import MPRester, Structure
+from pymatgen.ext.matproj import MPRester
+from pymatgen.core import Structure
 from pymatgen.entries.computed_entries import ComputedEntry
 
 from atomate.utils.utils import get_logger

--- a/atomate/vasp/builders/tasks_materials.py
+++ b/atomate/vasp/builders/tasks_materials.py
@@ -12,7 +12,7 @@ from atomate.vasp.builders.base import AbstractBuilder
 from atomate.vasp.builders.utils import dbid_to_str, dbid_to_int
 from atomate.utils.utils import get_database
 from monty.serialization import loadfn
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.analysis.structure_matcher import StructureMatcher, ElementComparator
 
 logger = get_logger(__name__)

--- a/atomate/vasp/firetasks/exchange.py
+++ b/atomate/vasp/firetasks/exchange.py
@@ -8,7 +8,7 @@ from atomate.vasp.database import VaspCalcDb
 from datetime import datetime
 import numpy as np
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.command_line.bader_caller import bader_analysis_from_path
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper, HeisenbergModel
 from pymatgen.analysis.magnetism import CollinearMagneticStructureAnalyzer, Ordering

--- a/atomate/vasp/firetasks/glue_tasks.py
+++ b/atomate/vasp/firetasks/glue_tasks.py
@@ -17,7 +17,7 @@ import gzip
 import os
 import re
 
-from pymatgen import MPRester
+from pymatgen.ext.matproj import MPRester
 from pymatgen.io.vasp.sets import get_vasprun_outcar
 from pymatgen.core.structure import Structure
 

--- a/atomate/vasp/firetasks/parse_outputs.py
+++ b/atomate/vasp/firetasks/parse_outputs.py
@@ -16,7 +16,7 @@ from atomate.vasp.config import DEFUSE_UNSUCCESSFUL
 from fireworks import FiretaskBase, FWAction, explicit_serialize
 from fireworks.utilities.fw_serializers import DATETIME_HANDLER
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.analysis.elasticity.elastic import ElasticTensor, ElasticTensorExpansion
 from pymatgen.analysis.elasticity.strain import Strain, Deformation
 from pymatgen.analysis.elasticity.stress import Stress

--- a/atomate/vasp/firetasks/tests/test_exchange.py
+++ b/atomate/vasp/firetasks/tests/test_exchange.py
@@ -20,7 +20,7 @@ from atomate.vasp.firetasks.exchange import (
 
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.io.vasp import Incar, Poscar, Potcar, Kpoints
 from pymatgen.io.vasp.sets import MPRelaxSet

--- a/atomate/vasp/firetasks/tests/test_polarization_to_db.py
+++ b/atomate/vasp/firetasks/tests/test_polarization_to_db.py
@@ -17,7 +17,7 @@ from atomate.utils.testing import AtomateTest
 from atomate.vasp.powerups import use_fake_vasp
 from atomate.vasp.firetasks.parse_outputs import PolarizationToDb
 
-from pymatgen.settings import SETTINGS
+from pymatgen.core import SETTINGS
 
 __author__ = 'Tess Smidt'
 __email__ = 'blondegeek@gmail.com'

--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -17,7 +17,7 @@ sequences of VASP calculations.
 
 from fireworks import Firework
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp.sets import (
     MPRelaxSet,
     MPScanRelaxSet,

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -20,7 +20,7 @@ from atomate.vasp.firetasks.write_inputs import ModifyIncar, ModifyPotcar, Modif
 from fireworks import Workflow, FileWriteTask
 from fireworks.core.firework import Tracker
 from fireworks.utilities.fw_utilities import get_slug
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 __author__ = "Anubhav Jain, Kiran Mathew, Alex Ganose"
 __email__ = "ajain@lbl.gov, kmathew@lbl.gov"

--- a/atomate/vasp/submission_filter.py
+++ b/atomate/vasp/submission_filter.py
@@ -3,7 +3,7 @@
 
 from monty.json import MSONable, MontyDecoder
 
-from pymatgen import MPRester
+from pymatgen.ext.matproj import MPRester
 from pymatgen.alchemy.filters import AbstractStructureFilter
 
 __author__ = 'Anubhav Jain <ajain@lbl.gov>, Kiran Mathew <kmathew@lbl.gov>'

--- a/atomate/vasp/tests/test_setup.py
+++ b/atomate/vasp/tests/test_setup.py
@@ -4,7 +4,7 @@
 import os
 import unittest
 
-from pymatgen import IStructure, Lattice
+from pymatgen.core import IStructure, Lattice
 from pymatgen.io.vasp import Incar, Poscar, Potcar, Kpoints
 from pymatgen.io.vasp.sets import MPRelaxSet
 

--- a/atomate/vasp/workflows/base/ferroelectric.py
+++ b/atomate/vasp/workflows/base/ferroelectric.py
@@ -9,7 +9,7 @@ from fireworks import Firework, Workflow
 
 from atomate.utils.utils import get_logger, get_a_unique_id
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from atomate.vasp.fireworks.core import OptimizeFW
 from atomate.vasp.fireworks.polarization import LcalcpolFW

--- a/atomate/vasp/workflows/tests/test_adsorbate_workflow.py
+++ b/atomate/vasp/workflows/tests/test_adsorbate_workflow.py
@@ -13,7 +13,7 @@ from atomate.vasp.workflows.base.adsorption import get_wf_slab, \
     get_slab_trans_params, MPSurfaceSet
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import Structure, Molecule, Lattice
+from pymatgen.core import Structure, Molecule, Lattice
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.core.surface import generate_all_slabs
 from pymatgen.transformations.advanced_transformations import SlabTransformation

--- a/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
+++ b/atomate/vasp/workflows/tests/test_bulk_modulus_workflow.py
@@ -15,7 +15,7 @@ from atomate.vasp.powerups import use_fake_vasp, use_no_vasp
 from atomate.vasp.workflows.presets.core import wf_bulk_modulus
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 

--- a/atomate/vasp/workflows/tests/test_elastic_workflow.py
+++ b/atomate/vasp/workflows/tests/test_elastic_workflow.py
@@ -19,7 +19,7 @@ from atomate.utils.testing import AtomateTest
 
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 __author__ = 'Kiran Mathew, Joseph Montoya'
 __email__ = 'montoyjh@lbl.gov'

--- a/atomate/vasp/workflows/tests/test_exchange_workflow.py
+++ b/atomate/vasp/workflows/tests/test_exchange_workflow.py
@@ -21,7 +21,7 @@ from atomate.utils.testing import AtomateTest, DB_DIR
 from atomate.utils.utils import get_a_unique_id
 
 from json import load
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 __author__ = "Nathan C. Frey"
 __email__ = "ncfrey@lbl.gov"

--- a/atomate/vasp/workflows/tests/test_ferroelectric_workflow.py
+++ b/atomate/vasp/workflows/tests/test_ferroelectric_workflow.py
@@ -2,7 +2,7 @@ import tarfile
 
 from pathlib import Path
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire

--- a/atomate/vasp/workflows/tests/test_magnetism_workflow.py
+++ b/atomate/vasp/workflows/tests/test_magnetism_workflow.py
@@ -14,7 +14,7 @@ from atomate.vasp.firetasks.parse_outputs import (
 from atomate.utils.testing import AtomateTest, DB_DIR
 
 from json import load
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 __author__ = "Matthew Horton"
 __email__ = "mkhorton@lbl.gov"

--- a/atomate/vasp/workflows/tests/test_nmr.py
+++ b/atomate/vasp/workflows/tests/test_nmr.py
@@ -13,7 +13,7 @@ from atomate.vasp.powerups import use_fake_vasp
 from atomate.vasp.workflows.presets.core import wf_nmr
 from atomate.utils.testing import AtomateTest
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 db_dir = os.path.join(module_dir, "..", "..", "..", "common", "test_files")

--- a/dev_scripts/gibbs.py
+++ b/dev_scripts/gibbs.py
@@ -8,7 +8,7 @@ from pymongo import MongoClient
 
 import numpy as np
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 __author__ = "Kiran Mathew"
 __email__ = "kmathew@lbl.gov"

--- a/docs/_sources/customizing_workflows.rst.txt
+++ b/docs/_sources/customizing_workflows.rst.txt
@@ -36,7 +36,7 @@ An example for adding an INCAR setting to use a different force convergence crit
 
     from atomate.vasp.workflows.presets.core import wf_elastic_constant
     from atomate.vasp.powerups import add_modify_incar
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')
@@ -74,7 +74,7 @@ To use a different functional, for instance in a optimization calculation, you c
     from fireworks import Workflow
     from atomate.vasp.fireworks.core import OptimizeFW
     from pymatgen.io.vasp.sets import MPRelaxSet
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     def get_optimize_wf(structure, name="optimization wf", vasp_input_set=None,
                         vasp_cmd="vasp", db_file=None, user_kpoints_settings=None,
@@ -134,7 +134,7 @@ KPOINTS settings can also be similarly customized using the above example. You c
 .. code-block:: python
 
     from pymatgen.io.vasp.sets import MPRelaxSet
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')
@@ -151,7 +151,7 @@ If you need more control, create the ``Kpoints`` object directly with pymatgen. 
 
     from pymatgen.io.vasp.sets import MPRelaxSet
     from pymatgen.io.vasp.inputs import Kpoints
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')
@@ -199,7 +199,7 @@ Which POTCAR file you want to use is controlled by the input set as well. The ea
 .. code-block:: python
 
     from pymatgen.io.vasp.sets import MPRelaxSet
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')

--- a/docs/_sources/gibbs_workflow_tutorial.rst.txt
+++ b/docs/_sources/gibbs_workflow_tutorial.rst.txt
@@ -91,7 +91,7 @@ In the directory you created, make a Python script named ``gibbs.py`` with the f
 
     #!/usr/bin/env python
     import numpy as np
-    from pymatgen import MPRester
+    from pymatgen.ext.matproj import MPRester
     from fireworks import LaunchPad
     from atomate.vasp.workflows.presets.core import wf_gibbs_free_energy
 
@@ -157,7 +157,7 @@ Simply add the following Python script (``gibbs-analysis.py``) to your folder an
 .. code-block:: python
 
     from atomate.vasp.database import VaspCalcDb
-    from pymatgen import Structure
+    from pymatgen.core import Structure
     import numpy as np
 
     import matplotlib.pyplot as plt

--- a/docs/_sources/running_workflows.rst.txt
+++ b/docs/_sources/running_workflows.rst.txt
@@ -128,7 +128,7 @@ In the same directory as the POSCAR, create a Python script named ``mgo_bandstru
 
     # Create a bandstructure from the workflow from the atomate presets
     import numpy as np
-    from pymatgen import Structure
+    from pymatgen.core import Structure
     from fireworks import LaunchPad
     from atomate.vasp.workflows.presets.core import wf_bandstructure
     from atomate.vasp.powerups import add_modify_incar

--- a/docs_rst/customizing_workflows.rst
+++ b/docs_rst/customizing_workflows.rst
@@ -36,7 +36,7 @@ An example for adding an INCAR setting to use a different force convergence crit
 
     from atomate.vasp.workflows.presets.core import wf_elastic_constant
     from atomate.vasp.powerups import add_modify_incar
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')
@@ -74,7 +74,7 @@ To use a different functional, for instance in a optimization calculation, you c
     from fireworks import Workflow
     from atomate.vasp.fireworks.core import OptimizeFW
     from pymatgen.io.vasp.sets import MPRelaxSet
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     def get_optimize_wf(structure, name="optimization wf", vasp_input_set=None,
                         vasp_cmd="vasp", db_file=None, user_kpoints_settings=None,
@@ -134,7 +134,7 @@ KPOINTS settings can also be similarly customized using the above example. You c
 .. code-block:: python
 
     from pymatgen.io.vasp.sets import MPRelaxSet
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')
@@ -151,7 +151,7 @@ If you need more control, create the ``Kpoints`` object directly with pymatgen. 
 
     from pymatgen.io.vasp.sets import MPRelaxSet
     from pymatgen.io.vasp.inputs import Kpoints
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')
@@ -199,7 +199,7 @@ Which POTCAR file you want to use is controlled by the input set as well. The ea
 .. code-block:: python
 
     from pymatgen.io.vasp.sets import MPRelaxSet
-    from pymatgen import Structure
+    from pymatgen.core import Structure
 
     # load your structure, e.g. from a POSCAR
     struct = Structure.from_file('POSCAR')

--- a/docs_rst/gibbs_workflow_tutorial.rst
+++ b/docs_rst/gibbs_workflow_tutorial.rst
@@ -91,7 +91,7 @@ In the directory you created, make a Python script named ``gibbs.py`` with the f
 
     #!/usr/bin/env python
     import numpy as np
-    from pymatgen import MPRester
+    from pymatgen.ext.matproj import MPRester
     from fireworks import LaunchPad
     from atomate.vasp.workflows.presets.core import wf_gibbs_free_energy
 
@@ -157,7 +157,7 @@ Simply add the following Python script (``gibbs-analysis.py``) to your folder an
 .. code-block:: python
 
     from atomate.vasp.database import VaspCalcDb
-    from pymatgen import Structure
+    from pymatgen.core import Structure
     import numpy as np
 
     import matplotlib.pyplot as plt

--- a/docs_rst/running_workflows.rst
+++ b/docs_rst/running_workflows.rst
@@ -128,7 +128,7 @@ In the same directory as the POSCAR, create a Python script named ``mgo_bandstru
 
     # Create a bandstructure from the workflow from the atomate presets
     import numpy as np
-    from pymatgen import Structure
+    from pymatgen.core import Structure
     from fireworks import LaunchPad
     from atomate.vasp.workflows.presets.core import wf_bandstructure
     from atomate.vasp.powerups import add_modify_incar

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tqdm==4.58.0
 pybtex==0.24.0
 ruamel.yaml==0.16.12
 pandas==1.2.2
-pymatgen==2021.3.3
+pymatgen==2022.0.3
 custodian==2021.2.8
 networkx==2.5
 pydash==4.9.2

--- a/scripts/atwf
+++ b/scripts/atwf
@@ -19,7 +19,8 @@ from atomate.utils.utils import get_wf_from_spec_dict, load_class
 from atomate.vasp.powerups import add_namefile, add_tags
 from atomate.vasp.workflows.presets import core
 
-from pymatgen import Structure, Lattice, MPRester
+from pymatgen.core import Structure, Lattice
+from pymatgen.ext.matproj import MPRester
 from pymatgen.util.testing import PymatgenTest
 
 default_yaml = """fireworks:


### PR DESCRIPTION
## Summary

The latest update to Pymatgen removed the `__init__.py` file such that import statements drawing from the package e.g. `from pymatgen import Structure` no longer work. There are a few of these across the repo. This PR fixes all of them I could find. Helpfully, this also makes it backwards compatible, since the specificity does not change any functionality.

* All statements of the form `from pymatgen import x` are now made more specific, e.g. `from pymatgen import Structure` is now `from pymatgen.core import Structure`.