### PR TITLE
better handling of dynamic powerups

### DIFF
--- a/atomate/common/powerups.py
+++ b/atomate/common/powerups.py
@@ -7,7 +7,8 @@ This module defines general powerups that can be used for all workflows
 from atomate.utils.utils import get_fws_and_tasks
 from fireworks import Workflow, FileWriteTask
 from fireworks.utilities.fw_utilities import get_slug
-from inspect import getmembers, isfunction, stack, getmodule
+from inspect import getmembers, isfunction
+import sys
 
 __author__ = "Janine George, Guido Petretto, Ryan Kingsbury"
 __email__ = (
@@ -221,7 +222,7 @@ def set_queue_adapter(
     return original_wf
 
 
-def get_powerup_dict():
+def get_powerup_dict(module):
     """
     Return a complete list of functions in any module where where this `get_powerup_dict` is called.
     Note: this is a quick and dirty way to serialize powerup functions for dynamic workflows.
@@ -229,14 +230,14 @@ def get_powerup_dict():
     Returns:
         A dict of {<function name> : <function object>}
     """
-    frm = stack()[1]
-    mod = getmodule(frm[0])
     return dict(
-        filter(lambda x: x[1].__module__ == mod.__name__, getmembers(mod, isfunction))
+        filter(
+            lambda x: x[1].__module__ == module.__name__, getmembers(module, isfunction)
+        )
     )
 
 
-local_names = get_powerup_dict()
+local_names = get_powerup_dict(sys.modules[__name__])
 
 
 def powerup_by_kwargs(wf, **kwargs):

--- a/atomate/common/powerups.py
+++ b/atomate/common/powerups.py
@@ -257,6 +257,7 @@ def powerup_by_kwargs(
         "atomate.qchem.powerups",
         "atomate.common.powerups",
     ]
+
     # user can add new modules containing custom powerups
     if add_powerup_module is not None:
         powerup_modules = add_powerup_module + powerup_modules

--- a/atomate/common/powerups.py
+++ b/atomate/common/powerups.py
@@ -257,7 +257,6 @@ def powerup_by_kwargs(
         "atomate.qchem.powerups",
         "atomate.common.powerups",
     ]
-
     # user can add new modules containing custom powerups
     if add_powerup_module is not None:
         powerup_modules = add_powerup_module + powerup_modules

--- a/atomate/common/powerups.py
+++ b/atomate/common/powerups.py
@@ -223,9 +223,9 @@ def set_queue_adapter(
 
 
 def powerup_by_kwargs(
-    wf,
+    original_wf: Workflow,
     add_powerup_module: List[str] = None,
-    **kwargs,
+    **powerup_kwargs,
 ):
     """
     apply powerups in the form using a kwargs dictionary of the form:
@@ -239,6 +239,15 @@ def powerup_by_kwargs(
                                                                 "update_dict" : {"foo" : "bar"}
                                                                 }
         )
+
+    Args:
+        original_wf: workflow that will be changed
+        add_powerup_module: user_made modules that contain powerups
+        powerup_kwargs: KWARGS used to apply any power:  {"add_modify_incar": {
+                                                            "modify_incar_params": {
+                                                            "incar_update": {"KPAR": 8}}
+                                                            }}
+
     """
     # a list of possible powerups in atomate (most specific first)
     powerup_modules = [
@@ -250,13 +259,13 @@ def powerup_by_kwargs(
     if add_powerup_module is not None:
         powerup_modules = add_powerup_module + powerup_modules
 
-    for k, v in kwargs.items():
+    for k, v in powerup_kwargs.items():
         for module_name in powerup_modules:
             try:
                 module = import_module(module_name)
                 powerup = getattr(module, k)
-                wf = powerup(wf, **v)
+                original_wf = powerup(original_wf, **v)
                 break
             except Exception:
                 pass
-    return wf
+    return original_wf

--- a/atomate/common/powerups.py
+++ b/atomate/common/powerups.py
@@ -243,10 +243,12 @@ def powerup_by_kwargs(
     Args:
         original_wf: workflow that will be changed
         add_powerup_module: user_made modules that contain powerups
-        powerup_kwargs: KWARGS used to apply any power:  {"add_modify_incar": {
-                                                            "modify_incar_params": {
-                                                            "incar_update": {"KPAR": 8}}
-                                                            }}
+        powerup_kwargs: KWARGS used to apply any power, EXAMPLE:
+                {"add_modify_incar": {
+                                      "modify_incar_params": {
+                                      "incar_update": {"KPAR": 8}}
+                                        }
+                }
 
     """
     # a list of possible powerups in atomate (most specific first)

--- a/atomate/common/tests/test_powerups.py
+++ b/atomate/common/tests/test_powerups.py
@@ -83,7 +83,16 @@ class TestPowerups(unittest.TestCase):
 
     def test_powerup_by_kwargs(self):
         my_wf = copy_wf(self.bs_wf)
-        my_wf = powerup_by_kwargs(my_wf, add_tags={"tags_list": ["foo", "bar"]})
+        my_wf = powerup_by_kwargs(
+            my_wf,
+            [
+                {"powerup_name": "add_tags", "kwargs": {"tags_list": ["foo", "bar"]}},
+                {
+                    "powerup_name": "atomate.common.powerups.add_priority",
+                    "kwargs": {"root_priority": 123},
+                },
+            ],
+        )
         self.assertEqual(my_wf.metadata["tags"], ["foo", "bar"])
 
     def test_set_queue_adapter(self):

--- a/atomate/common/tests/test_powerups.py
+++ b/atomate/common/tests/test_powerups.py
@@ -5,7 +5,12 @@ from atomate.vasp.workflows.base.core import get_wf
 from pymatgen.io.vasp.sets import MPRelaxSet
 from pymatgen.util.testing import PymatgenTest
 
-from atomate.common.powerups import set_queue_adapter, add_priority, add_tags
+from atomate.common.powerups import (
+    set_queue_adapter,
+    add_priority,
+    add_tags,
+    powerup_by_kwargs,
+)
 from fireworks import Firework, ScriptTask, Workflow
 
 __author__ = "Janine George, Guido Petretto"
@@ -75,6 +80,11 @@ class TestPowerups(unittest.TestCase):
                     v_found += 1
         self.assertEqual(b_found, 1)
         self.assertEqual(v_found, 4)
+
+    def test_powerup_by_kwargs(self):
+        my_wf = copy_wf(self.bs_wf)
+        my_wf = powerup_by_kwargs(my_wf, add_tags={"tags_list": ["foo", "bar"]})
+        self.assertEqual(my_wf.metadata["tags"], ["foo", "bar"])
 
     def test_set_queue_adapter(self):
         # test fw_name_constraint

--- a/atomate/vasp/firetasks/electrode_tasks.py
+++ b/atomate/vasp/firetasks/electrode_tasks.py
@@ -1,5 +1,4 @@
 import math
-from collections import defaultdict
 
 from fireworks import FiretaskBase, explicit_serialize, FWAction, Firework, Workflow
 from pymatgen.core import Structure
@@ -316,10 +315,13 @@ def get_powerup_wf(wf, fw_spec, additional_fields=None):
     Returns:
         Updated workflow
     """
-    d_pu = defaultdict(dict)
-    d_pu.update(fw_spec.get("vasp_powerups", {}))
+    powerup_list = []
+    powerup_list.extend(fw_spec.get("vasp_powerups", []))
     if additional_fields is not None:
-        d_pu["add_additional_fields_to_taskdocs"].update(
-            {"update_dict": additional_fields}
+        powerup_list.append(
+            {
+                "powerup_name": "add_additional_fields_to_taskdocs",
+                "kwargs": {"update_dict": additional_fields},
+            }
         )
-    return powerup_by_kwargs(wf, **d_pu)
+    return powerup_by_kwargs(wf, powerup_list)

--- a/atomate/vasp/firetasks/electrode_tasks.py
+++ b/atomate/vasp/firetasks/electrode_tasks.py
@@ -13,7 +13,7 @@ from atomate.vasp.fireworks.core import OptimizeFW, StaticFW
 
 from atomate.vasp.database import VaspCalcDb
 from atomate.vasp.firetasks import pass_vasp_result
-from atomate.vasp.powerups import powerup_by_kwargs, POWERUP_NAMES
+from atomate.common.powerups import powerup_by_kwargs
 
 __author__ = "Jimmy Shen"
 __email__ = "jmmshn@lbl.gov"
@@ -322,5 +322,4 @@ def get_powerup_wf(wf, fw_spec, additional_fields=None):
         d_pu["add_additional_fields_to_taskdocs"].update(
             {"update_dict": additional_fields}
         )
-    p_kwargs = {k: d_pu[k] for k in POWERUP_NAMES if k in d_pu}
-    return powerup_by_kwargs(wf, **p_kwargs)
+    return powerup_by_kwargs(wf, **d_pu)

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -9,7 +9,7 @@ from atomate.common.powerups import (
     add_additional_fields_to_taskdocs as common_add_additional_fields_to_taskdocs,
 )
 from atomate.common.powerups import add_tags as common_add_tags
-from atomate.common.powerups import get_powerup_dict
+from atomate.common.powerups import get_powerup_dict, local_names
 from atomate.utils.utils import get_meta_from_structure, get_fws_and_tasks
 from atomate.vasp.config import (
     ADD_NAMEFILE,
@@ -832,7 +832,7 @@ def use_fake_lobster(original_wf, ref_dirs, params_to_check=None):
     return original_wf
 
 
-local_names = get_powerup_dict()
+local_names.update(get_powerup_dict())
 
 
 def powerup_by_kwargs(wf, **kwargs):

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -1,5 +1,3 @@
-import sys
-
 from atomate.common.firetasks.glue_tasks import DeleteFiles
 from atomate.common.powerups import add_priority as common_add_priority
 from atomate.common.powerups import preserve_fworker as common_preserve_fworker
@@ -11,7 +9,6 @@ from atomate.common.powerups import (
     add_additional_fields_to_taskdocs as common_add_additional_fields_to_taskdocs,
 )
 from atomate.common.powerups import add_tags as common_add_tags
-from atomate.common.powerups import get_powerup_dict, local_names
 from atomate.utils.utils import get_meta_from_structure, get_fws_and_tasks
 from atomate.vasp.config import (
     ADD_NAMEFILE,
@@ -35,8 +32,6 @@ from fireworks.core.firework import Tracker
 
 __author__ = "Anubhav Jain, Kiran Mathew, Alex Ganose"
 __email__ = "ajain@lbl.gov, kmathew@lbl.gov"
-
-POWERUP_NAMES = []
 
 
 @deprecated(replacement=common_add_priority)
@@ -832,26 +827,3 @@ def use_fake_lobster(original_wf, ref_dirs, params_to_check=None):
                         )
 
     return original_wf
-
-
-local_names.update(get_powerup_dict(sys.modules[__name__]))
-
-
-def powerup_by_kwargs(wf, **kwargs):
-    """
-    apply powerups in the form using a kwargs dictionary of the form:
-    {
-        powerup_function_name1 : {parameter1 : value1, parameter2: value2},
-        powerup_function_name2 : {parameter1 : value1, parameter2: value2},
-    }
-
-    As an example:
-        power_up_by_kwargs( "add_additional_fields_to_taskdocs" : {
-                                                                "update_dict" : {"foo" : "bar"}
-                                                                }
-        )
-    """
-    print(local_names)
-    for k, v in kwargs.items():
-        wf = local_names[k](wf, **v)
-    return wf

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -9,6 +9,7 @@ from atomate.common.powerups import (
     add_additional_fields_to_taskdocs as common_add_additional_fields_to_taskdocs,
 )
 from atomate.common.powerups import add_tags as common_add_tags
+from atomate.common.powerups import get_powerup_dict
 from atomate.utils.utils import get_meta_from_structure, get_fws_and_tasks
 from atomate.vasp.config import (
     ADD_NAMEFILE,
@@ -831,17 +832,7 @@ def use_fake_lobster(original_wf, ref_dirs, params_to_check=None):
     return original_wf
 
 
-local_names = dict(locals())  # locals() changes as the program runs, make a copy here
-
-for k, v in local_names.items():
-    if (
-        hasattr(v, "__module__")
-        and v.__module__ == "atomate.vasp.powerups"
-        and k != "power_up_by_kwargs"
-    ):
-        POWERUP_NAMES.append(k)
-
-local_names = {k: v for k, v in local_names.items() if k in POWERUP_NAMES}
+local_names = get_powerup_dict()
 
 
 def powerup_by_kwargs(wf, **kwargs):

--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -1,3 +1,5 @@
+import sys
+
 from atomate.common.firetasks.glue_tasks import DeleteFiles
 from atomate.common.powerups import add_priority as common_add_priority
 from atomate.common.powerups import preserve_fworker as common_preserve_fworker
@@ -832,7 +834,7 @@ def use_fake_lobster(original_wf, ref_dirs, params_to_check=None):
     return original_wf
 
 
-local_names.update(get_powerup_dict())
+local_names.update(get_powerup_dict(sys.modules[__name__]))
 
 
 def powerup_by_kwargs(wf, **kwargs):
@@ -849,6 +851,7 @@ def powerup_by_kwargs(wf, **kwargs):
                                                                 }
         )
     """
+    print(local_names)
     for k, v in kwargs.items():
         wf = local_names[k](wf, **v)
     return wf

--- a/atomate/vasp/tests/test_vasp_powerups.py
+++ b/atomate/vasp/tests/test_vasp_powerups.py
@@ -18,6 +18,7 @@ from atomate.vasp.powerups import (
     clean_up_files,
     set_queue_options,
     use_potcar_spec,
+    powerup_by_kwargs,
 )
 from atomate.vasp.workflows.base.core import get_wf
 
@@ -243,6 +244,14 @@ class TestVaspPowerups(unittest.TestCase):
         for idx_fw, idx_t in idx_list:
             task = wf.fws[idx_fw].tasks[idx_t]
             self.assertTrue(task["potcar_spec"])
+
+    def test_powerup_by_kwargs(self):
+        my_wf = copy_wf(self.bs_wf)
+        my_wf = powerup_by_kwargs(my_wf, add_trackers={})
+        my_wf = powerup_by_kwargs(my_wf, add_tags={"tags_list": ["foo", "bar"]})
+        for fw in my_wf.fws:
+            self.assertEqual(len(fw.spec["_trackers"]), 2)
+        self.assertEqual(my_wf.metadata["tags"], ["foo", "bar"])
 
 
 def copy_wf(wf):

--- a/atomate/vasp/tests/test_vasp_powerups.py
+++ b/atomate/vasp/tests/test_vasp_powerups.py
@@ -18,8 +18,8 @@ from atomate.vasp.powerups import (
     clean_up_files,
     set_queue_options,
     use_potcar_spec,
-    powerup_by_kwargs,
 )
+from atomate.common.powerups import powerup_by_kwargs
 from atomate.vasp.workflows.base.core import get_wf
 
 from pymatgen.io.vasp.sets import MPRelaxSet

--- a/atomate/vasp/tests/test_vasp_powerups.py
+++ b/atomate/vasp/tests/test_vasp_powerups.py
@@ -247,8 +247,13 @@ class TestVaspPowerups(unittest.TestCase):
 
     def test_powerup_by_kwargs(self):
         my_wf = copy_wf(self.bs_wf)
-        my_wf = powerup_by_kwargs(my_wf, add_trackers={})
-        my_wf = powerup_by_kwargs(my_wf, add_tags={"tags_list": ["foo", "bar"]})
+        my_wf = powerup_by_kwargs(
+            my_wf, [{"powerup_name": "add_trackers", "kwargs": {}}]
+        )
+        my_wf = powerup_by_kwargs(
+            my_wf,
+            [{"powerup_name": "add_tags", "kwargs": {"tags_list": ["foo", "bar"]}}],
+        )
         for fw in my_wf.fws:
             self.assertEqual(len(fw.spec["_trackers"]), 2)
         self.assertEqual(my_wf.metadata["tags"], ["foo", "bar"])

--- a/atomate/vasp/workflows/base/electrode.py
+++ b/atomate/vasp/workflows/base/electrode.py
@@ -9,7 +9,7 @@ __author__ = "Jimmy Shen"
 __email__ = "jmmshn@lbl.gov"
 
 from atomate.vasp.fireworks import Firework, OptimizeFW, StaticFW, pass_vasp_result
-from atomate.vasp.powerups import powerup_by_kwargs
+from atomate.common.powerups import powerup_by_kwargs
 
 """
 Define workflow related to battery material simulation --- they all have a working ion

--- a/atomate/vasp/workflows/base/electrode.py
+++ b/atomate/vasp/workflows/base/electrode.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from fireworks import Workflow
 from pymatgen.core import Structure
 from pymatgen.analysis.structure_matcher import StructureMatcher
@@ -23,7 +25,7 @@ def get_ion_insertion_wf(
     db_file: str = DB_FILE,
     vasptodb_kwargs: dict = None,
     volumetric_data_type: str = "CHGCAR",
-    vasp_powerups: dict = None,
+    vasp_powerups: List[dict] = None,
     max_insertions: int = 4,
     allow_fizzled_parents: bool = True,
     optimizefw_kwargs: dict = None,
@@ -106,7 +108,7 @@ def get_ion_insertion_wf(
 
     # Apply the vasp powerup if present
     if vasp_powerups is not None:
-        wf = powerup_by_kwargs(wf, **vasp_powerups)
+        wf = powerup_by_kwargs(wf, vasp_powerups)
         for fw in wf.fws:
             fw.spec["vasp_powerups"] = vasp_powerups
 

--- a/atomate/vasp/workflows/tests/test_insertion_workflow.py
+++ b/atomate/vasp/workflows/tests/test_insertion_workflow.py
@@ -21,6 +21,9 @@ ref_dir = module_dir / "../../test_files"
 wf_dir = ref_dir / "insertion_wf"
 
 VASP_CMD = None  # for fake VASP
+DEBUG_MODE = (
+    False  # If true, retains the database and output dirs at the end of the test
+)
 
 
 class TestInsertionWorkflow(AtomateTest):

--- a/atomate/vasp/workflows/tests/test_insertion_workflow.py
+++ b/atomate/vasp/workflows/tests/test_insertion_workflow.py
@@ -41,19 +41,23 @@ class TestInsertionWorkflow(AtomateTest):
             working_ion="Mg",
             volumetric_data_type="AECCAR",
             db_file=db_dir / "db.json",
-            vasp_powerups={
-                "add_modify_incar": {
-                    "modify_incar_params": {"incar_update": {"KPAR": 8}}
+            vasp_powerups=[
+                {
+                    "powerup_name": "add_modify_incar",
+                    "kwargs": {"modify_incar_params": {"incar_update": {"KPAR": 8}}},
                 },
-                "use_fake_vasp": {
-                    "ref_dirs": calc_dirs,
-                    "check_incar": False,
-                    "check_kpoints": False,
-                    "check_poscar": False,
-                    "check_potcar": False,
+                {
+                    "powerup_name": "use_fake_vasp",
+                    "kwargs": {
+                        "ref_dirs": calc_dirs,
+                        "check_incar": False,
+                        "check_kpoints": False,
+                        "check_poscar": False,
+                        "check_potcar": False,
+                    },
                 },
-                "use_potcar_spec": {},
-            },
+                {"powerup_name": "use_potcar_spec", "kwargs": {}},
+            ],
             optimizefw_kwargs={"ediffg": -0.05},
         )
         wf = use_fake_vasp(

--- a/atomate/vasp/workflows/tests/test_raman_workflow.py
+++ b/atomate/vasp/workflows/tests/test_raman_workflow.py
@@ -9,7 +9,7 @@ import numpy as np
 from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
 
-from atomate.vasp.powerups import powerup_by_kwargs
+from atomate.common.powerups import powerup_by_kwargs
 from atomate.vasp.workflows.presets.core import wf_raman_spectra
 from atomate.utils.testing import AtomateTest
 

--- a/atomate/vasp/workflows/tests/test_raman_workflow.py
+++ b/atomate/vasp/workflows/tests/test_raman_workflow.py
@@ -9,61 +9,45 @@ import numpy as np
 from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
 
-from atomate.common.powerups import powerup_by_kwargs
+from atomate.vasp.powerups import use_fake_vasp
 from atomate.vasp.workflows.presets.core import wf_raman_spectra
 from atomate.utils.testing import AtomateTest
 
 from pymatgen.util.testing import PymatgenTest
 
-__author__ = "Kiran Mathew"
-__email__ = "kmathew@lbl.gov"
+__author__ = 'Kiran Mathew'
+__email__ = 'kmathew@lbl.gov'
 
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 db_dir = os.path.join(module_dir, "..", "..", "..", "common", "test_files")
 ref_dir = os.path.join(module_dir, "..", "..", "test_files")
 
-DEBUG_MODE = (
-    False  # If true, retains the database and output dirs at the end of the test
-)
-VASP_CMD = (
-    None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this command...
-)
+DEBUG_MODE = False  # If true, retains the database and output dirs at the end of the test
+VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this command...
 
 
 class TestRamanWorkflow(AtomateTest):
+
     def setUp(self):
         super(TestRamanWorkflow, self).setUp()
         self.struct_si = PymatgenTest.get_structure("Si")
-        self.raman_config = {
-            "MODES": [0, 1],
-            "STEP_SIZE": 0.005,
-            "VASP_CMD": ">>vasp_cmd<<",
-            "DB_FILE": ">>db_file<<",
-        }
+        self.raman_config = {"MODES": [0, 1], "STEP_SIZE": 0.005,
+                            "VASP_CMD": ">>vasp_cmd<<", "DB_FILE": ">>db_file<<"}
         self.wf = wf_raman_spectra(self.struct_si, self.raman_config)
 
     def _simulate_vasprun(self, wf):
         reference_dir = os.path.abspath(os.path.join(ref_dir, "raman_wf"))
-        si_ref_dirs = {
-            "structure optimization": os.path.join(reference_dir, "1"),
-            "static dielectric": os.path.join(reference_dir, "2"),
-            "raman_0_-0.005": os.path.join(reference_dir, "6"),
-            "raman_0_0.005": os.path.join(reference_dir, "5"),
-            "raman_1_-0.005": os.path.join(reference_dir, "4"),
-            "raman_1_0.005": os.path.join(reference_dir, "3"),
-        }
-        return powerup_by_kwargs(
-            wf, use_fake_vasp={"ref_dirs": si_ref_dirs, "params_to_check": ["ENCUT"]}
-        )
-        # return use_fake_vasp(wf, si_ref_dirs, params_to_check=["ENCUT"])
+        si_ref_dirs = {"structure optimization": os.path.join(reference_dir, "1"),
+                       "static dielectric": os.path.join(reference_dir, "2"),
+                       "raman_0_-0.005": os.path.join(reference_dir, "6"),
+                       "raman_0_0.005": os.path.join(reference_dir, "5"),
+                       "raman_1_-0.005": os.path.join(reference_dir, "4"),
+                       "raman_1_0.005": os.path.join(reference_dir, "3")}
+        return use_fake_vasp(wf, si_ref_dirs, params_to_check=["ENCUT"])
 
     def _check_run(self, d, mode):
-        if mode not in [
-            "structure optimization",
-            "static dielectric",
-            "raman_0_0.005",
-            "raman analysis",
-        ]:
+        if mode not in ["structure optimization", "static dielectric",
+                        "raman_0_0.005", "raman analysis"]:
             raise ValueError("Invalid mode!")
 
         if mode not in ["raman analysis"]:
@@ -71,62 +55,36 @@ class TestRamanWorkflow(AtomateTest):
             self.assertEqual(d["formula_anonymous"], "A")
             self.assertEqual(d["nelements"], 1)
             self.assertEqual(d["state"], "successful")
-            self.assertAlmostEqual(
-                d["calcs_reversed"][0]["output"]["structure"]["lattice"]["a"], 3.867, 2
-            )
+            self.assertAlmostEqual(d["calcs_reversed"][0]["output"]["structure"]["lattice"]["a"], 3.867, 2)
 
         if mode in ["structure optimization"]:
             self.assertAlmostEqual(d["output"]["energy"], -10.850, 2)
             self.assertAlmostEqual(d["output"]["energy_per_atom"], -5.425, 2)
 
         elif mode in ["static dielectric"]:
-            epsilon = [
-                [13.23245131, -1.98e-06, -1.4e-06],
-                [-1.98e-06, 13.23245913, 8.38e-06],
-                [-1.4e-06, 8.38e-06, 13.23245619],
-            ]
-            np.testing.assert_allclose(
-                epsilon, d["output"]["epsilon_static"], rtol=1e-5
-            )
+            epsilon = [[13.23245131, -1.98e-06, -1.4e-06],
+                       [-1.98e-06, 13.23245913, 8.38e-06],
+                       [-1.4e-06, 8.38e-06, 13.23245619]]
+            np.testing.assert_allclose(epsilon, d["output"]["epsilon_static"], rtol=1e-5)
 
         elif mode in ["raman_0_0.005"]:
-            epsilon = [
-                [13.16509632, 0.00850098, 0.00597267],
-                [0.00850097, 13.25477303, -0.02979572],
-                [0.00597267, -0.0297953, 13.28883867],
-            ]
-            np.testing.assert_allclose(
-                epsilon, d["output"]["epsilon_static"], rtol=1e-5
-            )
+            epsilon = [[13.16509632, 0.00850098, 0.00597267],
+                       [0.00850097, 13.25477303, -0.02979572],
+                       [0.00597267, -0.0297953, 13.28883867]]
+            np.testing.assert_allclose(epsilon, d["output"]["epsilon_static"], rtol=1e-5)
 
         elif mode in ["raman analysis"]:
-            freq = [
-                82.13378641656142,
-                82.1337379843688,
-                82.13373236539397,
-                3.5794336040310436e-07,
-                3.872360276932139e-07,
-                1.410955723105983e-06,
-            ]
+            freq = [82.13378641656142, 82.1337379843688, 82.13373236539397,
+                    3.5794336040310436e-07, 3.872360276932139e-07, 1.410955723105983e-06]
             np.testing.assert_allclose(freq, d["frequencies"], rtol=1e-5)
-            raman_tensor = {
-                "0": [
-                    [-0.14893062387265346, 0.01926196125448702, 0.013626954435454657],
-                    [0.019262321540910236, 0.03817444467845385, -0.06614541890150054],
-                    [0.013627229948601821, -0.06614564143135017, 0.11078513986463052],
-                ],
-                "1": [
-                    [-0.021545749071077102, -0.12132200642389818, -0.08578776196143767],
-                    [-0.12131975993142007, -0.00945267872479081, -0.004279822490713417],
-                    [-0.08578678706847546, -0.004279960247327641, 0.032660281203217366],
-                ],
-            }
-            np.testing.assert_allclose(
-                raman_tensor["0"], d["raman_tensor"]["0"], rtol=1e-5
-            )
-            np.testing.assert_allclose(
-                raman_tensor["1"], d["raman_tensor"]["1"], rtol=1e-5
-            )
+            raman_tensor = {'0': [[-0.14893062387265346, 0.01926196125448702, 0.013626954435454657],
+                                  [0.019262321540910236, 0.03817444467845385, -0.06614541890150054],
+                                  [0.013627229948601821, -0.06614564143135017, 0.11078513986463052]],
+                            '1': [[-0.021545749071077102, -0.12132200642389818, -0.08578776196143767],
+                                  [-0.12131975993142007, -0.00945267872479081, -0.004279822490713417],
+                                  [-0.08578678706847546, -0.004279960247327641, 0.032660281203217366]]}
+            np.testing.assert_allclose(raman_tensor["0"], d["raman_tensor"]["0"], rtol=1e-5)
+            np.testing.assert_allclose(raman_tensor["1"], d["raman_tensor"]["1"], rtol=1e-5)
 
     def test_wf(self):
         self.wf = self._simulate_vasprun(self.wf)
@@ -134,14 +92,10 @@ class TestRamanWorkflow(AtomateTest):
         self.assertEqual(len(self.wf.fws), len(self.raman_config["MODES"]) * 2 + 3)
 
         self.lp.add_wf(self.wf)
-        rapidfire(
-            self.lp, fworker=FWorker(env={"db_file": os.path.join(db_dir, "db.json")})
-        )
+        rapidfire(self.lp, fworker=FWorker(env={"db_file": os.path.join(db_dir, "db.json")}))
 
         # check relaxation
-        d = self.get_task_collection().find_one(
-            {"task_label": "structure optimization"}
-        )
+        d = self.get_task_collection().find_one({"task_label": "structure optimization"})
         self._check_run(d, mode="structure optimization")
 
         # check phonon DFPT calculation
@@ -157,7 +111,7 @@ class TestRamanWorkflow(AtomateTest):
         self._check_run(d, mode="raman analysis")
 
         wf = self.lp.get_wf_by_fw_id(1)
-        self.assertTrue(all([s == "COMPLETED" for s in wf.fw_states.values()]))
+        self.assertTrue(all([s == 'COMPLETED' for s in wf.fw_states.values()]))
 
 
 if __name__ == "__main__":

--- a/atomate/vasp/workflows/tests/test_raman_workflow.py
+++ b/atomate/vasp/workflows/tests/test_raman_workflow.py
@@ -9,45 +9,61 @@ import numpy as np
 from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
 
-from atomate.vasp.powerups import use_fake_vasp
+from atomate.vasp.powerups import powerup_by_kwargs
 from atomate.vasp.workflows.presets.core import wf_raman_spectra
 from atomate.utils.testing import AtomateTest
 
 from pymatgen.util.testing import PymatgenTest
 
-__author__ = 'Kiran Mathew'
-__email__ = 'kmathew@lbl.gov'
+__author__ = "Kiran Mathew"
+__email__ = "kmathew@lbl.gov"
 
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 db_dir = os.path.join(module_dir, "..", "..", "..", "common", "test_files")
 ref_dir = os.path.join(module_dir, "..", "..", "test_files")
 
-DEBUG_MODE = False  # If true, retains the database and output dirs at the end of the test
-VASP_CMD = None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this command...
+DEBUG_MODE = (
+    False  # If true, retains the database and output dirs at the end of the test
+)
+VASP_CMD = (
+    None  # If None, runs a "fake" VASP. Otherwise, runs VASP with this command...
+)
 
 
 class TestRamanWorkflow(AtomateTest):
-
     def setUp(self):
         super(TestRamanWorkflow, self).setUp()
         self.struct_si = PymatgenTest.get_structure("Si")
-        self.raman_config = {"MODES": [0, 1], "STEP_SIZE": 0.005,
-                            "VASP_CMD": ">>vasp_cmd<<", "DB_FILE": ">>db_file<<"}
+        self.raman_config = {
+            "MODES": [0, 1],
+            "STEP_SIZE": 0.005,
+            "VASP_CMD": ">>vasp_cmd<<",
+            "DB_FILE": ">>db_file<<",
+        }
         self.wf = wf_raman_spectra(self.struct_si, self.raman_config)
 
     def _simulate_vasprun(self, wf):
         reference_dir = os.path.abspath(os.path.join(ref_dir, "raman_wf"))
-        si_ref_dirs = {"structure optimization": os.path.join(reference_dir, "1"),
-                       "static dielectric": os.path.join(reference_dir, "2"),
-                       "raman_0_-0.005": os.path.join(reference_dir, "6"),
-                       "raman_0_0.005": os.path.join(reference_dir, "5"),
-                       "raman_1_-0.005": os.path.join(reference_dir, "4"),
-                       "raman_1_0.005": os.path.join(reference_dir, "3")}
-        return use_fake_vasp(wf, si_ref_dirs, params_to_check=["ENCUT"])
+        si_ref_dirs = {
+            "structure optimization": os.path.join(reference_dir, "1"),
+            "static dielectric": os.path.join(reference_dir, "2"),
+            "raman_0_-0.005": os.path.join(reference_dir, "6"),
+            "raman_0_0.005": os.path.join(reference_dir, "5"),
+            "raman_1_-0.005": os.path.join(reference_dir, "4"),
+            "raman_1_0.005": os.path.join(reference_dir, "3"),
+        }
+        return powerup_by_kwargs(
+            wf, use_fake_vasp={"ref_dirs": si_ref_dirs, "params_to_check": ["ENCUT"]}
+        )
+        # return use_fake_vasp(wf, si_ref_dirs, params_to_check=["ENCUT"])
 
     def _check_run(self, d, mode):
-        if mode not in ["structure optimization", "static dielectric",
-                        "raman_0_0.005", "raman analysis"]:
+        if mode not in [
+            "structure optimization",
+            "static dielectric",
+            "raman_0_0.005",
+            "raman analysis",
+        ]:
             raise ValueError("Invalid mode!")
 
         if mode not in ["raman analysis"]:
@@ -55,36 +71,62 @@ class TestRamanWorkflow(AtomateTest):
             self.assertEqual(d["formula_anonymous"], "A")
             self.assertEqual(d["nelements"], 1)
             self.assertEqual(d["state"], "successful")
-            self.assertAlmostEqual(d["calcs_reversed"][0]["output"]["structure"]["lattice"]["a"], 3.867, 2)
+            self.assertAlmostEqual(
+                d["calcs_reversed"][0]["output"]["structure"]["lattice"]["a"], 3.867, 2
+            )
 
         if mode in ["structure optimization"]:
             self.assertAlmostEqual(d["output"]["energy"], -10.850, 2)
             self.assertAlmostEqual(d["output"]["energy_per_atom"], -5.425, 2)
 
         elif mode in ["static dielectric"]:
-            epsilon = [[13.23245131, -1.98e-06, -1.4e-06],
-                       [-1.98e-06, 13.23245913, 8.38e-06],
-                       [-1.4e-06, 8.38e-06, 13.23245619]]
-            np.testing.assert_allclose(epsilon, d["output"]["epsilon_static"], rtol=1e-5)
+            epsilon = [
+                [13.23245131, -1.98e-06, -1.4e-06],
+                [-1.98e-06, 13.23245913, 8.38e-06],
+                [-1.4e-06, 8.38e-06, 13.23245619],
+            ]
+            np.testing.assert_allclose(
+                epsilon, d["output"]["epsilon_static"], rtol=1e-5
+            )
 
         elif mode in ["raman_0_0.005"]:
-            epsilon = [[13.16509632, 0.00850098, 0.00597267],
-                       [0.00850097, 13.25477303, -0.02979572],
-                       [0.00597267, -0.0297953, 13.28883867]]
-            np.testing.assert_allclose(epsilon, d["output"]["epsilon_static"], rtol=1e-5)
+            epsilon = [
+                [13.16509632, 0.00850098, 0.00597267],
+                [0.00850097, 13.25477303, -0.02979572],
+                [0.00597267, -0.0297953, 13.28883867],
+            ]
+            np.testing.assert_allclose(
+                epsilon, d["output"]["epsilon_static"], rtol=1e-5
+            )
 
         elif mode in ["raman analysis"]:
-            freq = [82.13378641656142, 82.1337379843688, 82.13373236539397,
-                    3.5794336040310436e-07, 3.872360276932139e-07, 1.410955723105983e-06]
+            freq = [
+                82.13378641656142,
+                82.1337379843688,
+                82.13373236539397,
+                3.5794336040310436e-07,
+                3.872360276932139e-07,
+                1.410955723105983e-06,
+            ]
             np.testing.assert_allclose(freq, d["frequencies"], rtol=1e-5)
-            raman_tensor = {'0': [[-0.14893062387265346, 0.01926196125448702, 0.013626954435454657],
-                                  [0.019262321540910236, 0.03817444467845385, -0.06614541890150054],
-                                  [0.013627229948601821, -0.06614564143135017, 0.11078513986463052]],
-                            '1': [[-0.021545749071077102, -0.12132200642389818, -0.08578776196143767],
-                                  [-0.12131975993142007, -0.00945267872479081, -0.004279822490713417],
-                                  [-0.08578678706847546, -0.004279960247327641, 0.032660281203217366]]}
-            np.testing.assert_allclose(raman_tensor["0"], d["raman_tensor"]["0"], rtol=1e-5)
-            np.testing.assert_allclose(raman_tensor["1"], d["raman_tensor"]["1"], rtol=1e-5)
+            raman_tensor = {
+                "0": [
+                    [-0.14893062387265346, 0.01926196125448702, 0.013626954435454657],
+                    [0.019262321540910236, 0.03817444467845385, -0.06614541890150054],
+                    [0.013627229948601821, -0.06614564143135017, 0.11078513986463052],
+                ],
+                "1": [
+                    [-0.021545749071077102, -0.12132200642389818, -0.08578776196143767],
+                    [-0.12131975993142007, -0.00945267872479081, -0.004279822490713417],
+                    [-0.08578678706847546, -0.004279960247327641, 0.032660281203217366],
+                ],
+            }
+            np.testing.assert_allclose(
+                raman_tensor["0"], d["raman_tensor"]["0"], rtol=1e-5
+            )
+            np.testing.assert_allclose(
+                raman_tensor["1"], d["raman_tensor"]["1"], rtol=1e-5
+            )
 
     def test_wf(self):
         self.wf = self._simulate_vasprun(self.wf)
@@ -92,10 +134,14 @@ class TestRamanWorkflow(AtomateTest):
         self.assertEqual(len(self.wf.fws), len(self.raman_config["MODES"]) * 2 + 3)
 
         self.lp.add_wf(self.wf)
-        rapidfire(self.lp, fworker=FWorker(env={"db_file": os.path.join(db_dir, "db.json")}))
+        rapidfire(
+            self.lp, fworker=FWorker(env={"db_file": os.path.join(db_dir, "db.json")})
+        )
 
         # check relaxation
-        d = self.get_task_collection().find_one({"task_label": "structure optimization"})
+        d = self.get_task_collection().find_one(
+            {"task_label": "structure optimization"}
+        )
         self._check_run(d, mode="structure optimization")
 
         # check phonon DFPT calculation
@@ -111,7 +157,7 @@ class TestRamanWorkflow(AtomateTest):
         self._check_run(d, mode="raman analysis")
 
         wf = self.lp.get_wf_by_fw_id(1)
-        self.assertTrue(all([s == 'COMPLETED' for s in wf.fw_states.values()]))
+        self.assertTrue(all([s == "COMPLETED" for s in wf.fw_states.values()]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Minor rework of how powerups are discovered during dynamic workflows.
- the `powerup_by_kwargs` function now has a sequence of the modules where it will look for powers (similar to a path variable)
- the user can also provide new modules that contain additional powerups using the `add_powerup_module` flag
- If a powerup is found, in any module, apply that powerup and stop looking