### PR TITLE
Small patch to add option to disable/enable Bader analysis on VASP ingestion

### DIFF
--- a/atomate/vasp/config.py
+++ b/atomate/vasp/config.py
@@ -38,6 +38,10 @@ STORE_VOLUMETRIC_DATA = ()  # e.g. ("chgcar", "aeccar0", "aeccar2", "elfcar", "l
 # useful for storing duplicate of FW.json
 STORE_ADDITIONAL_JSON = False
 
+# store Bader analysis when parsing VASP directories
+# (also requires "bader" executable to be in path)
+STORE_BADER = False
+
 # vasp output files that will be copied to lobster run
 VASP_OUTPUT_FILES = [
     "OUTCAR",

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -38,7 +38,7 @@ from atomate.utils.utils import get_uri
 
 from atomate.utils.utils import get_logger
 from atomate import __version__ as atomate_version
-from atomate.vasp.config import STORE_VOLUMETRIC_DATA, STORE_ADDITIONAL_JSON
+from atomate.vasp.config import STORE_VOLUMETRIC_DATA, STORE_ADDITIONAL_JSON, STORE_BADER
 
 __author__ = "Kiran Mathew, Shyue Ping Ong, Shyam Dwaraknath, Anubhav Jain"
 __email__ = "kmathew@lbl.gov"
@@ -47,7 +47,8 @@ __version__ = "0.1.0"
 
 logger = get_logger(__name__)
 
-BADER_EXE_EXISTS = which("bader") or which("bader.exe")
+STORE_BADER = STORE_BADER and (which("bader") or which("bader.exe"))
+
 
 
 class VaspDrone(AbstractDrone):
@@ -138,7 +139,7 @@ class VaspDrone(AbstractDrone):
         parse_locpot=True,
         additional_fields=None,
         use_full_uri=True,
-        parse_bader=BADER_EXE_EXISTS,
+        parse_bader=STORE_BADER,
         parse_chgcar=False,
         parse_aeccar=False,
         parse_potcar_file=True,


### PR DESCRIPTION
## Summary

Bader parsing already exists inside the VASP drone. Currently, it is enabled if `bader` is in your $PATH.

However, this behavior is problematic since some HPC systems automatically do this when you load VASP (e.g. Cori KNL `vasp/5.4.4-knl` module), which may result in a Bader analysis being performed when this was not desired, leading to longer jobs or an additional failure mode.

This PR adds a new config option to explicitly specify whether Bader analysis should be performed.