### PR TITLE
fix pymatgen-diffusion imports

### DIFF
--- a/atomate/vasp/firetasks/neb_tasks.py
+++ b/atomate/vasp/firetasks/neb_tasks.py
@@ -4,7 +4,7 @@ import shutil
 
 from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar, Kpoints, Poscar, Potcar
-from pymatgen.analysis.diffusion.neb.io import (
+from pymatgen_diffusion.neb.io import (
     MVLCINEBSet,
     get_endpoint_dist,
     get_endpoints_from_index,
@@ -360,7 +360,7 @@ class WriteNEBFromEndpoints(FiretaskBase):
         # Get number of images.
         nimages = user_incar_settings.get("IMAGES", self._get_nimages(ep0, ep1))
         if interpolation_type == "IDPP":
-            from pymatgen.analysis.diffusion.neb.pathfinder import IDPPSolver
+            from pymatgen_diffusion.neb.pathfinder import IDPPSolver
 
             obj = IDPPSolver.from_endpoints([ep0, ep1], nimages=nimages)
             images = obj.run(species=idpp_species)

--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -1134,7 +1134,7 @@ class NEBRelaxationFW(Firework):
                 user_kpoints_settings=user_kpoints_settings,
             )
         else:  # label == "ep0" or "ep1"
-            from pymatgen.analysis.diffusion.neb.io import MVLCINEBEndPointSet
+            from pymatgen_diffusion.neb.io import MVLCINEBEndPointSet
 
             vasp_input_set = MVLCINEBEndPointSet(
                 structure,

--- a/atomate/vasp/workflows/base/neb.py
+++ b/atomate/vasp/workflows/base/neb.py
@@ -6,7 +6,7 @@ This module defines the Nudged Elastic Band (NEB) workflow.
 
 from datetime import datetime
 
-from pymatgen.analysis.diffusion.neb.io import get_endpoints_from_index
+from pymatgen_diffusion.neb.io import get_endpoints_from_index
 
 from fireworks.core.firework import Workflow
 

--- a/atomate/vasp/workflows/tests/test_neb_workflow.py
+++ b/atomate/vasp/workflows/tests/test_neb_workflow.py
@@ -15,7 +15,7 @@ from pymatgen.core import Structure
 from pymatgen.util.testing import PymatgenTest
 
 try:
-    from pymatgen.analysis.diffusion.neb.io import get_endpoints_from_index
+    from pymatgen_diffusion.neb.io import get_endpoints_from_index
 
     pmgd = True
 


### PR DESCRIPTION
It seems that `pymatgen.analysis.diffusion` was removed from pymatgen and into `pymatgen-diffusion` without a deprecation message. Since code from this package is imported in `vasp_powerups.py`, this import problem caused basically all VASP workflows to break.