### PR TITLE
Fix bug in VASP IO write when `spec_structure_key` defined

### DIFF
--- a/atomate/vasp/firetasks/write_inputs.py
+++ b/atomate/vasp/firetasks/write_inputs.py
@@ -80,7 +80,7 @@ class WriteVaspFromIOSet(FiretaskBase):
             fw_struct = fw_spec.get(spec_structure_key)
             dd = vis.as_dict()
             dd["structure"] = fw_struct
-            vis.from_dict(dd)
+            vis = vis.from_dict(dd)
 
         potcar_spec = self.get("potcar_spec", False)
         vis.write_input(".", potcar_spec=potcar_spec)


### PR DESCRIPTION


## Summary
Current version of `WriteVaspFromIOSet` does not update the POSCAR using the `spec_structure_key` due to a bug on line 83 of `write_inputs.py`.

* Fix 1
`WriteVaspFromIOSet` does not correctly update the `vis` when `spec_structure_key` is set. The PR fixes the bug so the user-provided spec key can be passed.
