### PR TITLE
Fix gzip contcar issue

### DIFF
--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -142,11 +142,11 @@ class CopyFilesFromCalcLoc(FiretaskBase):
 
         for f in files_to_copy:
             prev_path_full = os.path.join(calc_dir, f)
-            dest_fname = self.get("name_prepend", "") + f + self.get("name_append", "")
+            f, ext = os.path.splitext(f)
+            dest_fname = self.get("name_prepend", "") + f + self.get("name_append", "") + ext
             dest_path = os.path.join(os.getcwd(), dest_fname)
 
             fileclient.copy(prev_path_full, dest_path)
-
 
 @explicit_serialize
 class DeleteFiles(FiretaskBase):

--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -95,10 +95,13 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         name_append (str): string to append to destination filenames.
         exclude_files (list): list of file names to be excluded. Accepts glob
             patterns.
+        decompress (bool): if True, files are decompressed after copy.
     """
 
     required_params = ["calc_loc"]
-    optional_params = ["filenames", "name_prepend", "name_append", "exclude_files"]
+    optional_params = ["filenames", "name_prepend",
+                       "name_append", "exclude_files",
+                       "decompress"]
 
     def run_task(self, fw_spec=None):
         calc_loc = get_calc_loc(self["calc_loc"], fw_spec["calc_locs"])
@@ -147,6 +150,8 @@ class CopyFilesFromCalcLoc(FiretaskBase):
             dest_path = os.path.join(os.getcwd(), dest_fname)
 
             fileclient.copy(prev_path_full, dest_path)
+            if self.get("decompress",False):
+                monty.shutil.decompress_file(dest_path)
 
 @explicit_serialize
 class DeleteFiles(FiretaskBase):

--- a/atomate/vasp/firetasks/glue_tasks.py
+++ b/atomate/vasp/firetasks/glue_tasks.py
@@ -290,15 +290,17 @@ class GetInterpolatedPOSCAR(FiretaskBase):
         # use CopyFilesFromCalcLoc to get files from previous locations.
         CopyFilesFromCalcLoc(
             calc_loc=self["start"],
-            filenames=["CONTCAR"],
+            filenames=["CONTCAR","CONTCAR.gz"],
             name_prepend=interpolate_folder + os.sep,
             name_append="_0",
+            decompress=True,
         ).run_task(fw_spec=fw_spec)
         CopyFilesFromCalcLoc(
             calc_loc=self["end"],
-            filenames=["CONTCAR"],
+            filenames=["CONTCAR","CONTCAR.gz"],
             name_prepend=interpolate_folder + os.sep,
             name_append="_1",
+            decompress=True,
         ).run_task(fw_spec=fw_spec)
 
         # assuming first calc_dir is polar structure for ferroelectric search


### PR DESCRIPTION
This should fix the issue of the interpolation FW which currently does not find the CONTCAR file if its gzipped.
If the CONTCAR file is not gzipped, it still works fine.

More generally, this fix allows CopyFilesFromCalcLoc to decompress compressed file after copy if wanted.

This fix should solve previous raised issues (I can find them back now).