### PR TITLE
small fixes to tests

### DIFF
--- a/atomate/utils/tests/test_database.py
+++ b/atomate/utils/tests/test_database.py
@@ -38,7 +38,7 @@ class DatabaseTests(unittest.TestCase):
 
     def test_s3_valid(self):
         with mock_s3():
-            conn = boto3.client("s3")
+            conn = boto3.resource('s3', region_name='us-east-1')
             conn.create_bucket(Bucket="test_bucket")
             index_store = MemoryStore()
             store = self.testdb.get_store("test")
@@ -51,7 +51,7 @@ class DatabaseTests(unittest.TestCase):
 
     def test_s3_not_valid(self):
         with mock_s3():
-            conn = boto3.client("s3")
+            conn = boto3.resource('s3', region_name='us-east-1')
             conn.create_bucket(Bucket="test_bucket_2")
             index_store = MemoryStore()
             store = self.testdb.get_store("test2")
@@ -62,7 +62,7 @@ class DatabaseTests(unittest.TestCase):
 
     def test_maggma_store_names(self):
         with mock_s3():
-            conn = boto3.client("s3")
+            conn = boto3.resource('s3', region_name='us-east-1')
             conn.create_bucket(Bucket="test_bucket")
             index_store = MemoryStore()
             store = self.testdb.get_store("test")
@@ -85,7 +85,7 @@ class DatabaseTests(unittest.TestCase):
         self.assertEqual(calc_db.collection.find_one()["data"], "12345")
 
         with mock_s3():
-            conn = boto3.client("s3")
+            conn = boto3.resource('s3', region_name='us-east-1')
             conn.create_bucket(Bucket="test_bucket")
             uri_db = TestToDb.from_db_file(db_dir + "/db_aws_uri.json")
             store = uri_db.get_store("test")

--- a/atomate/vasp/workflows/tests/test_insertion_workflow.py
+++ b/atomate/vasp/workflows/tests/test_insertion_workflow.py
@@ -22,9 +22,8 @@ wf_dir = ref_dir / "insertion_wf"
 class TestInsertionWorkflow(AtomateTest):
     def setUp(self):
         super().setUp()
-        input_output_dirs = ref_dir / "insertion_wf"
-        names = os.walk(input_output_dirs).__next__()[1]
-        calc_dirs = {n_: input_output_dirs / n_ for n_ in names}
+        names = os.walk(wf_dir).__next__()[1]
+        calc_dirs = {n_: wf_dir / n_ for n_ in names}
         base_struct = Structure.from_file(wf_dir / "YPO4-static/inputs/POSCAR")
         sm = StructureMatcher(ltol=0.6, stol=0.6, angle_tol=9)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pymatgen
 pymongo
 pyyaml==5.4.1
 ruamel.yaml==0.17.9
-scipy==1.7.0
+scipy==1.7.2
 tqdm==4.61.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,6 @@ per-file-ignores =
 
 [isort]
 profile = black
+
+[tool:pytest]
+addopts = --ignore=atomate/qchem/test_files


### PR DESCRIPTION
## Summary

- fixed redundant code in insertion test
- changed from `boto3.client` to `boto3.resources` to better match what `maggma` does.  Also I was failing tests because it seems like the AWS API no longer liked me using `boto3.client.create_bucket` in the way this was originally written.
- Install attempts produced an error saying that have to choose a different `scipy` version (Ubuntu with python 3.9 and 3.10) so I bumped it to the nearest > version.
- Not super sure about the last one: but since we have turned off `qchem` tests on the GitHub workflows should we turn it off in `setup.cfg` as well?  It took a long time for me to figure out why all my tests were failing.