### PR TITLE
atwf add POSCAR not working

### DIFF
--- a/scripts/atwf
+++ b/scripts/atwf
@@ -78,7 +78,7 @@ def _get_wf(args, structure):
         return func(structure)
 
     else:
-        d = yaml.load(default_yaml)
+        d = yaml.safe_load(default_yaml)
         return get_wf_from_spec_dict(structure, d, args.common_param_updates)
 
 


### PR DESCRIPTION
`atwf add POSCAR` errors out due to the `yaml.load` command here

The current version of `yaml.load` requires a `Loader` kwarg or just calling `safe_load` instead.
See here for more detail.
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation