### PR TITLE
Phonopy QHA fixed missing att

### DIFF
--- a/atomate/vasp/analysis/phonopy.py
+++ b/atomate/vasp/analysis/phonopy.py
@@ -53,7 +53,7 @@ def get_phonopy_gibbs(
     )
 
     # gibbs free energy and temperature
-    max_t_index = phonopy_qha._qha._max_t_index
+    max_t_index = phonopy_qha._qha._len
     G = phonopy_qha.get_gibbs_temperature()[:max_t_index]
     T = phonopy_qha._qha._temperatures[:max_t_index]
     return G, T
@@ -178,7 +178,7 @@ def get_phonopy_thermal_expansion(
     )
 
     # thermal expansion coefficient and temperature
-    max_t_index = phonopy_qha._qha._max_t_index
-    alpha = phonopy_qha.get_thermal_expansion()[:max_t_index]
+    max_t_index = phonopy_qha._qha._len
+    alpha = phonopy_qha.get_thermal_expansion()[: max_t_index]
     T = phonopy_qha._qha._temperatures[:max_t_index]
     return alpha, T

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 custodian==2022.1.17
 FireWorks==1.9.7
-maggma==0.39.0
+maggma==0.44.0
 monty==2021.6.10
 networkx==2.5.1
 numpy

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         install_requires=[
             "custodian>=2019.8.24",
             "FireWorks>=1.4.0",
-            "maggma>=0.39.0",
+            "maggma>=0.44.0",
             "monty>=2.0.6",
             "networkx",
             "numpy",


### PR DESCRIPTION
## Fixed attribute change related to Phonopy QHA change #271 

I don't know the original version of `phonopy` that references the `_max_t_index` attribute but it appears they now use `self._len` in the same way: 
Examples:
https://github.com/phonopy/phonopy/blob/ac7abb7e4bbbd3e45d76d21cf3e722176830a9e1/phonopy/qha/core.py#L258

https://github.com/phonopy/phonopy/blob/ac7abb7e4bbbd3e45d76d21cf3e722176830a9e1/phonopy/qha/core.py#L263

The source of the `self._len` is listed below and should be the same as the `_max_t_index`.

```
self._num_elems = len(self._temperatures)
```
https://github.com/phonopy/phonopy/blob/ac7abb7e4bbbd3e45d76d21cf3e722176830a9e1/phonopy/qha/core.py#L364

----

```
        beta = [0.0]
        for i in range(1, self._num_elems - 1):
            dt = self._temperatures[i + 1] - self._temperatures[i - 1]
            dv = self._equiv_volumes[i + 1] - self._equiv_volumes[i - 1]
            beta.append(dv / dt / self._equiv_volumes[i])

        self._thermal_expansions = beta
```
https://github.com/phonopy/phonopy/blob/ac7abb7e4bbbd3e45d76d21cf3e722176830a9e1/phonopy/qha/core.py#L1040

----

```
self._len = len(self._thermal_expansions)
```
https://github.com/phonopy/phonopy/blob/ac7abb7e4bbbd3e45d76d21cf3e722176830a9e1/phonopy/qha/core.py#L375


