### PR TITLE
From `monty` to `shutil` `which`

### DIFF
--- a/atomate/common/firetasks/glue_tasks.py
+++ b/atomate/common/firetasks/glue_tasks.py
@@ -99,9 +99,13 @@ class CopyFilesFromCalcLoc(FiretaskBase):
     """
 
     required_params = ["calc_loc"]
-    optional_params = ["filenames", "name_prepend",
-                       "name_append", "exclude_files",
-                       "decompress"]
+    optional_params = [
+        "filenames",
+        "name_prepend",
+        "name_append",
+        "exclude_files",
+        "decompress",
+    ]
 
     def run_task(self, fw_spec=None):
         calc_loc = get_calc_loc(self["calc_loc"], fw_spec["calc_locs"])
@@ -146,12 +150,15 @@ class CopyFilesFromCalcLoc(FiretaskBase):
         for f in files_to_copy:
             prev_path_full = os.path.join(calc_dir, f)
             f, ext = os.path.splitext(f)
-            dest_fname = self.get("name_prepend", "") + f + self.get("name_append", "") + ext
+            dest_fname = (
+                self.get("name_prepend", "") + f + self.get("name_append", "") + ext
+            )
             dest_path = os.path.join(os.getcwd(), dest_fname)
 
             fileclient.copy(prev_path_full, dest_path)
-            if self.get("decompress",False):
+            if self.get("decompress", False):
                 monty.shutil.decompress_file(dest_path)
+
 
 @explicit_serialize
 class DeleteFiles(FiretaskBase):

--- a/atomate/qchem/firetasks/tests/test_critic2.py
+++ b/atomate/qchem/firetasks/tests/test_critic2.py
@@ -2,8 +2,8 @@ import json
 import os
 import shutil
 import unittest
+from shutil import which
 
-from monty.os.path import which
 from pymatgen.io.qchem.outputs import QCOutput
 
 from atomate.qchem.firetasks.critic2 import ProcessCritic2, RunCritic2

--- a/atomate/vasp/analysis/phonopy.py
+++ b/atomate/vasp/analysis/phonopy.py
@@ -179,6 +179,6 @@ def get_phonopy_thermal_expansion(
 
     # thermal expansion coefficient and temperature
     max_t_index = phonopy_qha._qha._len
-    alpha = phonopy_qha.get_thermal_expansion()[: max_t_index]
+    alpha = phonopy_qha.get_thermal_expansion()[:max_t_index]
     T = phonopy_qha._qha._temperatures[:max_t_index]
     return alpha, T

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -420,7 +420,7 @@ class VaspDrone(AbstractDrone):
                     d["output"][k] = d_calc_final["output"][k]
 
             # store optical data, overwrites the LOPTICS data
-            if d["input"]["incar"].get("ALGO") == 'CHI':
+            if d["input"]["incar"].get("ALGO") == "CHI":
                 for k in ["optical_absorption_coeff", "dielectric"]:
                     d["output"][k] = d_calc_final["output"][k]
 
@@ -588,7 +588,7 @@ class VaspDrone(AbstractDrone):
             d["output"]["optical_absorption_coeff"] = vrun.optical_absorption_coeff
 
         # parse output from response function
-        if vrun.incar.get("ALGO") == 'CHI':
+        if vrun.incar.get("ALGO") == "CHI":
             dielectric = vrun.dielectric
             d["output"]["dielectric"] = dict(
                 energy=dielectric[0], real=dielectric[1], imag=dielectric[2]

--- a/atomate/vasp/drones.py
+++ b/atomate/vasp/drones.py
@@ -12,11 +12,11 @@ import re
 import traceback
 import warnings
 from fnmatch import fnmatch
+from shutil import which
 
 import numpy as np
 from monty.io import zopen
 from monty.json import jsanitize
-from monty.os.path import which
 from pymatgen.apps.borg.hive import AbstractDrone
 from pymatgen.command_line.bader_caller import bader_analysis_from_path
 from pymatgen.core.composition import Composition

--- a/atomate/vasp/firetasks/absorption_tasks.py
+++ b/atomate/vasp/firetasks/absorption_tasks.py
@@ -1,16 +1,6 @@
-import os
-from importlib import import_module
-
-import numpy as np
-
-from monty.serialization import dumpfn
 from fireworks import FiretaskBase, explicit_serialize
-from fireworks.utilities.dict_mods import apply_mod
-from pymatgen.core.structure import Structure
-from pymatgen.io.vasp import Incar, Poscar, Potcar, PotcarSingle, Kpoints
 from pymatgen.io.vasp.sets import MPAbsorptionSet
-from pymatgen.io.vasp.outputs import Vasprun
-from atomate.utils.utils import env_chk, load_class
+
 
 @explicit_serialize
 class WriteVaspAbsorptionFromPrev(FiretaskBase):
@@ -25,6 +15,7 @@ class WriteVaspAbsorptionFromPrev(FiretaskBase):
         "potcar_spec"
 
     """
+
     optional_params = [
         "prev_calc_dir",
         "structure",
@@ -37,7 +28,7 @@ class WriteVaspAbsorptionFromPrev(FiretaskBase):
         "ncores",
         "nedos",
         "potcar_spec",
-        "other_params"
+        "other_params",
     ]
 
     def run_task(self, fw_spec):

--- a/atomate/vasp/firetasks/glue_tasks.py
+++ b/atomate/vasp/firetasks/glue_tasks.py
@@ -290,14 +290,14 @@ class GetInterpolatedPOSCAR(FiretaskBase):
         # use CopyFilesFromCalcLoc to get files from previous locations.
         CopyFilesFromCalcLoc(
             calc_loc=self["start"],
-            filenames=["CONTCAR","CONTCAR.gz"],
+            filenames=["CONTCAR", "CONTCAR.gz"],
             name_prepend=interpolate_folder + os.sep,
             name_append="_0",
             decompress=True,
         ).run_task(fw_spec=fw_spec)
         CopyFilesFromCalcLoc(
             calc_loc=self["end"],
-            filenames=["CONTCAR","CONTCAR.gz"],
+            filenames=["CONTCAR", "CONTCAR.gz"],
             name_prepend=interpolate_folder + os.sep,
             name_append="_1",
             decompress=True,

--- a/atomate/vasp/firetasks/tests/test_exchange.py
+++ b/atomate/vasp/firetasks/tests/test_exchange.py
@@ -1,8 +1,8 @@
 import os
 import unittest
+from shutil import which
 
 import pandas as pd
-from monty.os.path import which
 from pymatgen.core import Structure
 
 from atomate.utils.testing import AtomateTest

--- a/atomate/vasp/workflows/tests/test_exchange_workflow.py
+++ b/atomate/vasp/workflows/tests/test_exchange_workflow.py
@@ -1,10 +1,10 @@
 import os
 import unittest
+from shutil import which
 
 import pandas as pd
 from fireworks import FWorker
 from fireworks.core.rocket_launcher import rapidfire
-from monty.os.path import which
 from pymatgen.core import Structure
 
 from atomate.utils.testing import AtomateTest

--- a/atomate/vasp/workflows/tests/test_magnetism_workflow.py
+++ b/atomate/vasp/workflows/tests/test_magnetism_workflow.py
@@ -1,8 +1,8 @@
 import os
 import unittest
 from json import load
+from shutil import which
 
-from monty.os.path import which
 from pymatgen.core import Structure
 
 from atomate.utils.testing import DB_DIR, AtomateTest


### PR DESCRIPTION
Similar housekeeping PR as https://github.com/materialsproject/pymatgen/pull/2417/commits/a6f0a723c9087cd368b77e1183f260121e993349 and https://github.com/materialsproject/atomate2/pull/92 to replace the soon-to-be deprecated `monty.os.path.which` with standard library's `shutil.which`.