### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 custodian==2022.1.17
-FireWorks==1.9.7
+FireWorks==2.0.3
 maggma==0.44.0
 monty==2021.6.10
 networkx==2.5.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         zip_safe=False,
         install_requires=[
             "custodian>=2019.8.24",
-            "FireWorks>=1.4.0",
+            "FireWorks>=2.0.3",
             "maggma>=0.44.0",
             "monty>=2.0.6",
             "networkx",


### PR DESCRIPTION
FireWorks > 2 is required for compatibility with the latest pymongo (>4). 

Currently, `pip install atomate` will result in a non-functional installation that yields the following error due to FireWorks 1.9.7 being incompatible with `pymongo` > 4

```
Traceback (most recent call last):
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/fireworks/scripts/lpad_run.py", line 115, in get_lp
    return LaunchPad.from_file(args.launchpad_file)
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/fireworks/utilities/fw_serializers.py", line 295, in from_file
    return cls.from_format(f.read(), f_format=f_format)
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/fireworks/utilities/fw_serializers.py", line 265, in from_format
    return cls.from_dict(reconstitute_dates(dct))
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/fireworks/core/launchpad.py", line 317, in from_dict
    return LaunchPad(d['host'], port, name, username, password,
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/fireworks/core/launchpad.py", line 220, in __init__
    self.connection = MongoClient(self.host, self.port, ssl=self.ssl,
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/pymongo/mongo_client.py", line 739, in __init__
    dict(common.validate(keyword_opts.cased_key(k), v) for k, v in keyword_opts.items())
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/pymongo/mongo_client.py", line 739, in <genexpr>
    dict(common.validate(keyword_opts.cased_key(k), v) for k, v in keyword_opts.items())
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/pymongo/common.py", line 754, in validate
    value = validator(option, value)
  File "/global/home/users/rkingsbury/.conda/envs/qcnew/lib/python3.9/site-packages/pymongo/common.py", line 159, in raise_config_error
    raise ConfigurationError("Unknown option %s" % (key,))
pymongo.errors.ConfigurationError: Unknown option ssl_ca_certs
```

