### PR TITLE
QChemDrone: fix Frequency parsing for single atoms

### DIFF
--- a/atomate/qchem/drones.py
+++ b/atomate/qchem/drones.py
@@ -232,7 +232,8 @@ class QChemDrone(AbstractDrone):
                     ]
             if d["output"]["job_type"] in ["freq", "frequency"]:
                 d["output"]["frequencies"] = d_calc_final["frequencies"]
-                d["output"]["frequency_modes"] = d_calc_final["frequency_mode_vectors"]
+                # Note: for single-atom freq calcs, this key may not exist
+                d["output"]["frequency_modes"] = d_calc_final.get("frequency_mode_vectors", [])
                 d["output"]["enthalpy"] = d_calc_final["total_enthalpy"]
                 d["output"]["entropy"] = d_calc_final["total_entropy"]
                 if d["input"]["job_type"] in ["opt", "optimization", "ts"]:


### PR DESCRIPTION
## Summary

Frequency calculations for single atoms may not have a `frequency_mode_vectors` key in their output, which was causing the Drone to fail parsing these calculations.
