### PR TITLE
updated lobster_tests with recent pymatgen changes

### DIFF
--- a/atomate/vasp/firetasks/tests/test_lobster_tasks.py
+++ b/atomate/vasp/firetasks/tests/test_lobster_tasks.py
@@ -111,7 +111,7 @@ class TestLobsterRunToDb(AtomateTest):
         with open("task_lobster.json") as f:
             load_dict = json.load(f)
         self.assertEqual(load_dict["formula_pretty"], "K2Sn2O3")
-        self.assertListEqual(load_dict["output"]["chargespilling"], [0.008, 0.008])
+        self.assertListEqual(load_dict["output"]["charge_spilling"], [0.008, 0.008])
 
     def test_mongodb(self):
         try:
@@ -128,7 +128,7 @@ class TestLobsterRunToDb(AtomateTest):
         coll = self.get_task_collection("lobster")
         load_dict = coll.find_one({"formula_pretty": "K2Sn2O3"})
         self.assertEqual(load_dict["formula_pretty"], "K2Sn2O3")
-        self.assertListEqual(load_dict["output"]["chargespilling"], [0.008, 0.008])
+        self.assertListEqual(load_dict["output"]["charge_spilling"], [0.008, 0.008])
         self.assertNotIn("lobster_icohplist", load_dict)
 
     def test_mongodb_more_files(self):
@@ -155,7 +155,7 @@ class TestLobsterRunToDb(AtomateTest):
         coll = self.get_task_collection("lobster")
         load_dict = coll.find_one({"formula_pretty": "K2Sn2O3"})
         self.assertEqual(load_dict["formula_pretty"], "K2Sn2O3")
-        self.assertListEqual(load_dict["output"]["chargespilling"], [0.008, 0.008])
+        self.assertListEqual(load_dict["output"]["charge_spilling"], [0.008, 0.008])
         db = self.get_task_database()
         gfs = gridfs.GridFS(db, "lobster_files")
         results = gfs.find({})
@@ -172,7 +172,7 @@ class TestLobsterRunToDb(AtomateTest):
         with open("task_lobster.json") as f:
             load_dict = json.load(f)
         self.assertEqual(load_dict["formula_pretty"], "Si")
-        self.assertListEqual(load_dict["output"]["chargespilling"], [0.0147, 0.0147])
+        self.assertListEqual(load_dict["output"]["charge_spilling"], [0.0147, 0.0147])
 
 
 class TestRunLobster(AtomateTest):

--- a/atomate/vasp/workflows/tests/test_lobster_workflow.py
+++ b/atomate/vasp/workflows/tests/test_lobster_workflow.py
@@ -101,13 +101,13 @@ class TestWFLobster(AtomateTest):
         self.assertEqual(d["state"], "successful")
 
         if mode in ["lobsternormal", "lobsternormal_delete_wavecars"]:
-            self.assertListEqual(d["output"]["chargespilling"], [0.0147, 0.0147])
+            self.assertListEqual(d["output"]["charge_spilling"], [0.0147, 0.0147])
             self.assertListEqual(d["output"]["elements"], ["Si"])
-            self.assertListEqual(d["output"]["basistype"], ["pbeVaspFit2015"])
+            self.assertListEqual(d["output"]["basis_type"], ["pbeVaspFit2015"])
             self.assertListEqual(
-                d["output"]["basisfunctions"], [["3s", "3p_y", "3p_z", "3p_x"]]
+                d["output"]["basis_functions"], [["3s", "3p_y", "3p_z", "3p_x"]]
             )
-            self.assertTrue(d["output"]["hasDOSCAR"])
+            self.assertTrue(d["output"]["has_doscar"])
             if database:
                 self.assertNotIn("cohpcar_id", d)
                 self.assertIn("icooplist_id", d)
@@ -252,13 +252,13 @@ class TestWFLobsterTestBasis(AtomateTest):
         self.assertEqual(d["state"], "successful")
 
         if mode in ["lobsternormal"]:
-            self.assertListEqual(d["output"]["chargespilling"], [0.0027, 0.0027])
+            self.assertListEqual(d["output"]["charge_spilling"], [0.0027, 0.0027])
             self.assertListEqual(d["output"]["elements"], ["F", "Cd"])
             self.assertListEqual(
-                d["output"]["basistype"], ["pbeVaspFit2015", "pbeVaspFit2015"]
+                d["output"]["basis_type"], ["pbeVaspFit2015", "pbeVaspFit2015"]
             )
             self.assertListEqual(
-                d["output"]["basisfunctions"],
+                d["output"]["basis_functions"],
                 [
                     ["2s", "2p_y", "2p_z", "2p_x"],
                     [
@@ -274,7 +274,7 @@ class TestWFLobsterTestBasis(AtomateTest):
                     ],
                 ],
             )
-            self.assertTrue(d["output"]["hasDOSCAR"])
+            self.assertTrue(d["output"]["has_doscar"])
 
     def _single_vasp_lobster(self, fake=True):
         # add the workflow

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,6 @@
+pymatgen==2023.3.10
+custodian==2023.3.10
+boto3==1.17.97
 Flask==2.1.3
 coverage==5.5
 moto==3.1.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-custodian==2022.5.26
+pymatgen==2023.3.10
+custodian==2023.3.10
 FireWorks==2.0.3
 maggma==0.48.1
 monty==2022.9.9
@@ -9,7 +10,6 @@ paramiko==2.11.0
 pydash==5.1.0
 pymatgen-analysis-diffusion==2022.7.21
 pymatgen-analysis-defects==2022.9.14
-pymatgen==2022.9.8
 pymongo==4.2.0
 ruamel.yaml==0.17.21
 scipy==1.9.1


### PR DESCRIPTION
## Summary

#770 PR updated the pymatgen version in CI and requirements leading to failing lobster tests.

### Fix

- Lobsterout parser keys in pymatgen has been updated > tests need to be updated accordingly

